### PR TITLE
Misc improvements

### DIFF
--- a/ptf
+++ b/ptf
@@ -79,6 +79,7 @@ config_default = {
     # Test behavior options
     "relax"              : False,
     "test_params"        : "None",
+    "failfast"           : False,
     "fail_skipped"       : False,
     "default_timeout"    : 2.0,
     "default_negative_timeout" : 0.1,
@@ -205,6 +206,8 @@ be subtracted from the result by prefixing them with the '^' character.  """
     group = parser.add_argument_group("Test behavior options")
     group.add_argument("--relax", action="store_true",
                       help="Relax packet match checks allowing other packets")
+    group.add_argument("--failfast", action="store_true",
+                      help="Stop running tests as soon as one fails")
     test_params_help = """Set test parameters: key=val;... (see --list)
     """
     group.add_argument("-t", "--test-params", help=test_params_help)
@@ -596,6 +599,10 @@ if __name__ == "__main__":
         result = runner.run(t)
         run_failures.extend(result.failures)
         run_errors.extend(result.errors)
+
+        if config["failfast"] and not result.wasSuccessful():
+            logging.info("Test failed and failfast mode enabled, stopping")
+            break
 
     ptf.open_logfile('main')
     if ptf.testutils.skipped_test_count > 0:

--- a/ptf
+++ b/ptf
@@ -21,6 +21,7 @@ import random
 import signal
 import fnmatch
 import copy
+from collections import OrderedDict
 
 root_dir = os.path.dirname(os.path.realpath(__file__))
 
@@ -57,6 +58,8 @@ config_default = {
     "test_spec"          : "",
     "test_file"          : None,
     "test_dir"           : None,
+    "test_order"         : "default",
+    "test_order_seed"    : 0xaba,
 
     # Switch connection options
     "platform"           : "eth",
@@ -160,13 +163,22 @@ be subtracted from the result by prefixing them with the '^' character.  """
     parser.add_argument("--allow-user", action="store_true",
                         help="Proceed even if ptf is not run as root")
 
-    # Needed for p4factory
     parser.add_argument("--pypath", dest="pypath", action="append")
 
     group = parser.add_argument_group("Test selection options")
     group.add_argument("-f", "--test-file", help="File of tests to run, one per line")
     group.add_argument("--test-dir", type=str, action=ActionTestDir,
                        required=True, help="Directory containing tests")
+    test_order_help = """Choose the order in which the tests will be run:
+    default (tests are run in the order in which they appear on command line),
+    lexico (use default string ordering on test names),
+    rand (random order, use --test-order-seed to specify a seed)
+    """
+    group.add_argument("--test-order",
+                       choices=["default", "lexico", "rand"],
+                       help=test_order_help)
+    group.add_argument("--test-order-seed", type=int,
+                       help="Specify seed to randomize test order")
 
     group = parser.add_argument_group("Switch connection options")
     group.add_argument("-P", "--platform", help="Platform module name")
@@ -317,7 +329,7 @@ def load_test_modules(config):
     (module, dictionary from test names to test classes).
     """
 
-    result = {}
+    result = OrderedDict()
 
     for root, dirs, filenames in os.walk(config["test_dir"]):
         # Iterate over each python file
@@ -368,7 +380,7 @@ def prune_tests(test_specs, test_modules):
     @param test_modules Same format as the output of load_test_modules.
     @returns Same format as the output of load_test_modules.
     """
-    result = {}
+    result = OrderedDict()
     for e in test_specs:
         matched = False
 
@@ -381,7 +393,7 @@ def prune_tests(test_specs, test_modules):
         for (modname, (mod, tests)) in test_modules.items():
             for (testname, test) in tests.items():
                 if e in test._groups or e == "%s.%s" % (modname, testname):
-                    result.setdefault(modname, (mod, {}))
+                    result.setdefault(modname, (mod, OrderedDict()))
                     if not negated:
                         # if not hasattr(test, "_versions") or version in test._versions:
                         result[modname][1][testname] = test
@@ -497,12 +509,16 @@ if config["list_test_names"]:
     sys.exit(0)
 
 # Generate the test suite
-#@todo Decide if multiple suites are ever needed
-suite = unittest.TestSuite()
-
+test_suite = []
 for (modname, (mod, tests)) in test_modules.items():
     for (testname, test) in tests.items():
-        suite.addTest(test())
+        test_suite.append(test())
+if config["test_order"] == "lexico":
+    test_suite.sort()
+elif config["test_order"] == "rand":
+    seed = config["test_order_seed"]
+    random.seed(seed)
+    random.shuffle(test_suite)
 
 # Allow platforms to import each other
 sys.path.append(config["platform_dir"])
@@ -572,9 +588,15 @@ if __name__ == "__main__":
         runner = xmlrunner.XMLTestRunner(output=config["xunit_dir"],
                                          outsuffix="",
                                          verbosity=2)
-        result = runner.run(suite)
     else:
-        result = unittest.TextTestRunner(verbosity=2).run(suite)
+        runner = unittest.TextTestRunner(verbosity=2)
+    run_failures = []
+    run_errors = []
+    for t in test_suite:
+        result = runner.run(t)
+        run_failures.extend(result.failures)
+        run_errors.extend(result.errors)
+
     ptf.open_logfile('main')
     if ptf.testutils.skipped_test_count > 0:
         ts = " tests"
@@ -590,7 +612,7 @@ if __name__ == "__main__":
 
     profiler_teardown(profiler)
 
-    if result.failures or result.errors:
+    if run_failures or run_errors:
         # exit(1) hangs sometimes
         os._exit(1)
     if ptf.testutils.skipped_test_count > 0 and config["fail_skipped"]:

--- a/src/ptf/base_tests.py
+++ b/src/ptf/base_tests.py
@@ -23,3 +23,19 @@ class BaseTest(unittest.TestCase):
 
     def tearDown(self):
         logging.info("** END TEST CASE " + str(self))
+
+    def before_send(self, pkt, device_number=0, port_number=-1):
+        """
+        This function is meant to be overwritten in children classes if
+        needed. It is called every time a packet is about to be send.
+        """
+        # print ":".join("{:02x}".format(ord(c)) for c in pkt)
+        pass
+
+    def at_receive(self, pkt, device_number=0, port_number=-1):
+        """
+        This function is meant to be overwritten in children classes if
+        needed. It is called every time a packet has been received.
+        """
+        # print ":".join("{:02x}".format(ord(c)) for c in pkt)
+        pass

--- a/src/ptf/base_tests.py
+++ b/src/ptf/base_tests.py
@@ -21,6 +21,9 @@ class BaseTest(unittest.TestCase):
         ptf.open_logfile(str(self))
         logging.info("** START TEST CASE " + str(self))
 
+    def run(self, result=None):
+        unittest.TestCase.run(self, result)
+
     def tearDown(self):
         logging.info("** END TEST CASE " + str(self))
 


### PR DESCRIPTION
This pull request adds the following features:
- failfast mode (enable with --failfast): test execution stops as soon as one test fails
- before_send and at_receive 'hooks': stub methods added to BaseTest class, called when a packet is sent (resp. received), can be overloaded by children classes when needed
- ability to specify execution order for tests using --test-order: choices are 'default' (command line order), 'lexico' (string ordering on test names), 'rand' (random, seed can be specified using --test-order-seed)
