### PR TITLE
clarified verification error messages

### DIFF
--- a/src/ptf/testutils.py
+++ b/src/ptf/testutils.py
@@ -1460,7 +1460,7 @@ def verify_packet(test, pkt, port_id):
     (rcv_device, rcv_port, rcv_pkt, pkt_time) = dp_poll(
         test, device_number=device, port_number=port, timeout=2, exp_pkt=pkt
     )
-    test.assertTrue(rcv_pkt != None, "Did not receive pkt on device %d, port %r" % (device, port))
+    test.assertTrue(rcv_pkt != None, "Did not receive expected pkt on device %d, port %r" % (device, port))
 
 def verify_no_packet(test, pkt, port_id, timeout=None):
     """
@@ -1545,7 +1545,7 @@ def verify_packets_any(test, pkt, ports=[], device_number=0):
             verify_no_packet(test, pkt, (device, port))
     verify_no_other_packets(test)
 
-    test.assertTrue(received == True, "Did not receive pkt on any of ports %r for device %d" % (ports, device_number))
+    test.assertTrue(received == True, "Did not receive expected pkt on any of ports %r for device %d" % (ports, device_number))
 
 def verify_any_packet_any_port(test, pkts=[], ports=[], device_number=0):
     """
@@ -1574,7 +1574,7 @@ def verify_any_packet_any_port(test, pkts=[], ports=[], device_number=0):
                 received = True
     verify_no_other_packets(test, device_number=device_number)
 
-    test.assertTrue(received == True, "Did not receive pkt on any of ports %r for device %d" % (ports, device_number))
+    test.assertTrue(received == True, "Did not receive expected pkt(s) on any of ports %r for device %d" % (ports, device_number))
     return match_index
 
 def verify_each_packet_on_each_port(test, pkts=[], ports=[], device_number=0):
@@ -1596,7 +1596,7 @@ def verify_each_packet_on_each_port(test, pkts=[], ports=[], device_number=0):
             port_number=port,
             exp_pkt=pkt
         )
-        test.assertTrue(rcv_pkt != None, "Did not receive pkt on port %d for device %d" %(port, device_number))
+        test.assertTrue(rcv_pkt != None, "Did not receive expected pkt(s) on port %d for device %d" %(port, device_number))
 
     verify_no_other_packets(test, device_number=device_number)
 
@@ -1606,7 +1606,7 @@ def verify_packet_prefix(test, pkt, port, len, device_number=0):
     """
     logging.debug("Checking for pkt on port %r", port)
     (rcv_device, rcv_port, rcv_pkt, pkt_time) = test.dataplane.poll(port_number=port, timeout=2, exp_pkt=str(pkt)[:len])
-    test.assertTrue(rcv_pkt != None, "Did not receive pkt on %r" % port)
+    test.assertTrue(rcv_pkt != None, "Did not receive expected pkt on %r" % port)
 
 
 __all__ = list(set(locals()) - _import_blacklist)


### PR DESCRIPTION
Clarified that verification failed to receive 'expected' packets.