### PR TITLE
Set if status for nn dataplane

### DIFF
--- a/ptf_nn/ptf_nn_agent.py
+++ b/ptf_nn/ptf_nn_agent.py
@@ -200,6 +200,8 @@ class IfaceMgr(threading.Thread):
                      self.dev, self.port, self.iface_name))
 
     def run(self):
+        # run this loop in case the interface goes down by external action
+        # or the interface disappeares
         while True:
             # wait until the port goes up
             while True:

--- a/ptf_nn/ptf_nn_agent.py
+++ b/ptf_nn/ptf_nn_agent.py
@@ -21,6 +21,7 @@
 #
 
 import sys
+import os
 import argparse
 import time
 import struct
@@ -78,6 +79,11 @@ def get_if_status(iff):
     s.close()
     flags = struct.unpack('16sh', result)[1]
     return flags & IFF_UP > 0
+
+def if_exists(iff):
+    ifaces = os.listdir('/sys/class/net')
+
+    return iff in ifaces
 
 # Taken from ptf parser
 class ActionInterface(argparse.Action):
@@ -197,7 +203,7 @@ class IfaceMgr(threading.Thread):
         while True:
             # wait until the port goes up
             while True:
-                if get_if_status(self.iface_name):
+                if if_exists(self.iface_name) and get_if_status(self.iface_name):
                     break
                 time.sleep(1)
 

--- a/ptf_nn/ptf_nn_agent.py
+++ b/ptf_nn/ptf_nn_agent.py
@@ -34,6 +34,8 @@ except ImportError:
 import threading
 import os
 import logging
+from fcntl import ioctl
+from socket import AF_NETLINK, SOCK_DGRAM
 
 # copied from ptf.netutils
 # From bits/ioctls.h
@@ -44,7 +46,6 @@ SIOCSIFFLAGS   = 0x8914          # set the active flag word of the device
 IFF_UP         = 0x0001
 
 def get_if(iff, cmd):
-    from fcntl import ioctl
     s = socket.socket()
     ifreq = ioctl(s, cmd, struct.pack("16s16x",iff))
     s.close()
@@ -58,8 +59,6 @@ def get_mac(iff):
         ['%02x' % ord(char) for char in get_if(iff, SIOCGIFHWADDR)[18:24]])
 
 def set_if_status(iff, status):
-    from socket import AF_NETLINK, SOCK_DGRAM
-    from fcntl import ioctl
     s = socket.socket()
     ifr = struct.pack('16sh', iff, 0)
     result = ioctl(s, SIOCGIFFLAGS, ifr)
@@ -72,6 +71,13 @@ def set_if_status(iff, status):
     ioctl(s, SIOCSIFFLAGS, ifr)
     s.close()
 
+def get_if_status(iff):
+    s = socket.socket()
+    ifr = struct.pack('16sh', iff, 0)
+    result = ioctl(s, SIOCGIFFLAGS, ifr)
+    s.close()
+    flags = struct.unpack('16sh', result)[1]
+    return flags & IFF_UP > 0
 
 # Taken from ptf parser
 class ActionInterface(argparse.Action):
@@ -152,9 +158,6 @@ class IfaceMgr(threading.Thread):
         self.dev = dev
         self.port = port
         self.iface_name = iface_name
-        self.socket = socket.socket(socket.AF_PACKET, socket.SOCK_RAW,
-                                    socket.htons(0x03))
-        self.socket.bind((iface_name, 0))
 
     def forward(self, p):
         # can that conflict with sniff?
@@ -180,20 +183,40 @@ class IfaceMgr(threading.Thread):
     def get_ctrs(self):
         return self.rx_ctr, self.tx_ctr
 
-    def port_up(self, status):
-        set_if_status(self.dev, True)
-        logger.debug("IfaceMgr {}-{} ({}) status changed to UP".format(
-                self.dev, self.port, self.iface_name))
+    def port_up(self):
+        set_if_status(self.iface_name, True)
+        logger.debug("IfaceMgr {}-{} ({}) status set to UP".format(
+                     self.dev, self.port, self.iface_name))
 
-    def port_down(self, status):
-        set_if_status(self.dev, False)
-        logger.debug("IfaceMgr {}-{} ({}) status changed to DOWN".format(
-                self.dev, self.port, self.iface_name))
+    def port_down(self):
+        set_if_status(self.iface_name, False)
+        logger.debug("IfaceMgr {}-{} ({}) status set to DOWN".format(
+                     self.dev, self.port, self.iface_name))
 
     def run(self):
         while True:
-            msg = self.socket.recv(4096)
-            self.received(msg)
+            # wait until the port goes up
+            while True:
+                if get_if_status(self.iface_name):
+                    break
+                time.sleep(1)
+
+            logger.debug("IfaceMgr {}-{} ({}) status changed to UP".format(
+                         self.dev, self.port, self.iface_name))
+            try:
+                self.socket = socket.socket(socket.AF_PACKET, socket.SOCK_RAW,
+                                            socket.htons(0x03))
+                self.socket.bind((self.iface_name, 0))
+                logger.debug("IfaceMgr {}-{} ({}) AF_PACKET socket is open".format(
+                             self.dev, self.port, self.iface_name))
+                while True:
+                    msg = self.socket.recv(4096)
+                    self.received(msg)
+            except socket.error as err:
+                logger.debug("IfaceMgr {}-{} ({}) Error reading from the socket.".format(
+                             self.dev, self.port, self.iface_name))
+                self.socket.close()
+
 
 class NanomsgMgr(threading.Thread):
     MSG_TYPE_PORT_ADD = 0

--- a/ptf_nn/ptf_nn_agent.py
+++ b/ptf_nn/ptf_nn_agent.py
@@ -201,7 +201,7 @@ class IfaceMgr(threading.Thread):
 
     def run(self):
         # run this loop in case the interface goes down by external action
-        # or the interface disappeares
+        # or the interface disappears
         while True:
             # wait until the port goes up
             while True:

--- a/src/ptf/dataplane.py
+++ b/src/ptf/dataplane.py
@@ -208,6 +208,9 @@ class DataPlanePacketSourceNN(DataPlanePacketSourceIface):
     MSG_TYPE_INFO_REQ = 5
     MSG_TYPE_INFO_REP = 6
 
+    MSG_PORT_STATUS_UP = 0
+    MSG_PORT_STATUS_DOWN = 1
+
     MSG_INFO_TYPE_HWADDR = 0
     MSG_INFO_TYPE_CTRS = 1
 


### PR DESCRIPTION
This pull request gives the PTF NN agent the ability to wait for an interface to become available before receiving packets. The agent will also bring an interface up / down based on `MSG_PORT_STATUS_UP` / `MSG_PORT_STATUS_DOWN` messages.