### PR TITLE
dataplane: Fix race access in stop_pcap(self)

### DIFF
--- a/src/ptf/dataplane.py
+++ b/src/ptf/dataplane.py
@@ -795,5 +795,7 @@ class DataPlane(Thread):
 
     def stop_pcap(self):
         if self.pcap_writer:
-            self.pcap_writer.close()
-            self.pcap_writer = None
+            with self.cvar:
+                self.pcap_writer.close()
+                self.pcap_writer = None
+                self.cvar.notify_all()


### PR DESCRIPTION
There might be racy access to pcap_writer from stop_pcap(self)
while receiving packets by DataPlane thread.

The issue might be reproduced with simple send-only scenario:

    class Dummy(some_base_test):
        def runTest(self):
            pkt = simple_tcp_packet(eth_dst='00:22:22:22:22:22',
                                    eth_src='00:11:11:11:11:11',
                                    ip_dst='10.0.0.1',
                                    ip_id=101,
                                    ip_ttl=64)

            for i in range(0, 1000):
                send_packet(self, 0, str(pkt))

Fixed by locking cvar in stop_pcap(self) before close pcap_writer.

Signed-off-by: Vadim Kochan <vadymk@mellanox.com>