### PR TITLE
testutils: Add ecn & dscp params to simple_xxx_packet funcs

### DIFF
--- a/src/ptf/testutils.py
+++ b/src/ptf/testutils.py
@@ -53,6 +53,15 @@ def ipv6_filter(pkt_str):
 def not_ipv6_filter(pkt_str):
     return not ipv6_filter(pkt_str)
 
+def ip_make_tos(tos, ecn, dscp):
+    if ecn is not None:
+        tos = (tos & ~(0x3)) | ecn
+
+    if dscp is not None:
+        tos = (tos & ~(0xfc)) | (dscp << 2)
+
+    return tos
+
 def simple_tcp_packet(pktlen=100,
                       eth_dst='00:01:02:03:04:05',
                       eth_src='00:06:07:08:09:0a',
@@ -63,6 +72,8 @@ def simple_tcp_packet(pktlen=100,
                       ip_src='192.168.0.1',
                       ip_dst='192.168.0.2',
                       ip_tos=0,
+                      ip_ecn=None,
+                      ip_dscp=None,
                       ip_ttl=64,
                       ip_id=0x0001,
                       ip_frag=0,
@@ -86,6 +97,8 @@ def simple_tcp_packet(pktlen=100,
     @param ip_src IP source
     @param ip_dst IP destination
     @param ip_tos IP ToS
+    @param ip_ecn IP ToS ECN
+    @param ip_dscp IP ToS DSCP
     @param ip_ttl IP TTL
     @param ip_id IP ID
     @param tcp_dport TCP destination port
@@ -105,6 +118,8 @@ def simple_tcp_packet(pktlen=100,
         tcp_hdr = scapy.TCP(sport=tcp_sport, dport=tcp_dport, flags=tcp_flags)
     else:
         tcp_hdr = scapy.TCP(sport=tcp_sport, dport=tcp_dport, flags=tcp_flags, chksum=0)
+
+    ip_tos = ip_make_tos(ip_tos, ip_ecn, ip_dscp)
 
     # Note Dot1Q.id is really CFI
     if (dl_vlan_enable):
@@ -135,6 +150,8 @@ def simple_tcpv6_packet(pktlen=100,
                         ipv6_src='2001:db8:85a3::8a2e:370:7334',
                         ipv6_dst='2001:db8:85a3::8a2e:370:7335',
                         ipv6_tc=0,
+                        ipv6_ecn=None,
+                        ipv6_dscp=None,
                         ipv6_hlim=64,
                         ipv6_fl=0,
                         tcp_sport=1234,
@@ -153,6 +170,8 @@ def simple_tcpv6_packet(pktlen=100,
     @param ipv6_src IPv6 source
     @param ipv6_dst IPv6 destination
     @param ipv6_tc IPv6 traffic class
+    @param ipv6_ecn IPv6 traffic class ECN
+    @param ipv6_dscp IPv6 traffic class DSCP
     @param ipv6_ttl IPv6 hop limit
     @param ipv6_fl IPv6 flow label
     @param tcp_dport TCP destination port
@@ -165,6 +184,8 @@ def simple_tcpv6_packet(pktlen=100,
 
     if MINSIZE > pktlen:
         pktlen = MINSIZE
+
+    ipv6_tc = ip_make_tos(ipv6_tc, ipv6_ecn, ipv6_dscp)
 
     pkt = scapy.Ether(dst=eth_dst, src=eth_src)
     if dl_vlan_enable or vlan_vid or vlan_pcp:
@@ -185,6 +206,8 @@ def simple_udp_packet(pktlen=100,
                       ip_src='192.168.0.1',
                       ip_dst='192.168.0.2',
                       ip_tos=0,
+                      ip_ecn=None,
+                      ip_dscp=None,
                       ip_ttl=64,
                       udp_sport=1234,
                       udp_dport=80,
@@ -206,6 +229,8 @@ def simple_udp_packet(pktlen=100,
     @param ip_src IP source
     @param ip_dst IP destination
     @param ip_tos IP ToS
+    @param ip_ecn IP ToS ECN
+    @param ip_dscp IP ToS DSCP
     @param ip_ttl IP TTL
     @param udp_dport UDP destination port
     @param udp_sport UDP source port
@@ -222,6 +247,8 @@ def simple_udp_packet(pktlen=100,
         udp_hdr = scapy.UDP(sport=udp_sport, dport=udp_dport)
     else:
         udp_hdr = scapy.UDP(sport=udp_sport, dport=udp_dport, chksum=0)
+
+    ip_tos = ip_make_tos(ip_tos, ip_ecn, ip_dscp)
 
     # Note Dot1Q.id is really CFI
     if (dl_vlan_enable):
@@ -256,6 +283,8 @@ def simple_geneve_packet(pktlen=300,
                         ip_src='192.168.0.1',
                         ip_dst='192.168.0.2',
                         ip_tos=0,
+                        ip_ecn=None,
+                        ip_dscp=None,
                         ip_ttl=64,
                         ip_id=0x0001,
                         udp_sport=1234,
@@ -281,6 +310,8 @@ def simple_geneve_packet(pktlen=300,
     @param ip_src IP source
     @param ip_dst IP destination
     @param ip_tos IP ToS
+    @param ip_ecn IP ToS ECN
+    @param ip_dscp IP ToS DSCP
     @param ip_ttl IP TTL
     @param ip_id IP ID
     @param udp_sport UDP source port
@@ -303,6 +334,8 @@ def simple_geneve_packet(pktlen=300,
         udp_hdr = scapy.UDP(sport=udp_sport, dport=udp_dport)
     else:
         udp_hdr = scapy.UDP(sport=udp_sport, dport=udp_dport, chksum=0)
+
+    ip_tos = ip_make_tos(ip_tos, ip_ecn, ip_dscp)
 
     # Note Dot1Q.id is really CFI
     if (dl_vlan_enable):
@@ -339,6 +372,8 @@ def simple_nvgre_packet(pktlen=300,
                       ip_src='192.168.0.1',
                       ip_dst='192.168.0.2',
                       ip_tos=0,
+                      ip_ecn=None,
+                      ip_dscp=None,
                       ip_ttl=64,
                       ip_id=0x0001,
                       ip_ihl=None,
@@ -361,6 +396,8 @@ def simple_nvgre_packet(pktlen=300,
     @param ip_src IP source
     @param ip_dst IP destination
     @param ip_tos IP ToS
+    @param ip_ecn IP ToS ECN
+    @param ip_dscp IP ToS DSCP
     @param ip_ttl IP TTL
     @param ip_id IP ID
     @param nvgre_version Version
@@ -379,6 +416,8 @@ def simple_nvgre_packet(pktlen=300,
         pktlen = MINSIZE
 
     nvgre_hdr = scapy.NVGRE(vsid=nvgre_tni, flowid=nvgre_flowid)
+
+    ip_tos = ip_make_tos(ip_tos, ip_ecn, ip_dscp)
 
     # Note Dot1Q.id is really CFI
     if (dl_vlan_enable):
@@ -414,6 +453,8 @@ def simple_vxlan_packet(pktlen=300,
                         ip_src='192.168.0.1',
                         ip_dst='192.168.0.2',
                         ip_tos=0,
+                        ip_ecn=None,
+                        ip_dscp=None,
                         ip_ttl=64,
                         ip_id=0x0001,
                         udp_sport=1234,
@@ -438,6 +479,8 @@ def simple_vxlan_packet(pktlen=300,
     @param ip_src IP source
     @param ip_dst IP destination
     @param ip_tos IP ToS
+    @param ip_ecn IP ToS ECN
+    @param ip_dscp IP ToS DSCP
     @param ip_ttl IP TTL
     @param ip_id IP ID
     @param udp_sport UDP source port
@@ -461,6 +504,8 @@ def simple_vxlan_packet(pktlen=300,
         udp_hdr = scapy.UDP(sport=udp_sport, dport=udp_dport)
     else:
         udp_hdr = scapy.UDP(sport=udp_sport, dport=udp_dport, chksum=0)
+
+    ip_tos = ip_make_tos(ip_tos, ip_ecn, ip_dscp)
 
     # Note Dot1Q.id is really CFI
     if (dl_vlan_enable):
@@ -498,6 +543,8 @@ def simple_vxlanv6_packet(pktlen=300,
                           ipv6_dst='3::4',
                           ipv6_fl=0,
                           ipv6_tc=0,
+                          ipv6_ecn=None,
+                          ipv6_dscp=None,
                           ipv6_hlim=64,
                           udp_sport=1234,
                           udp_dport=4789,
@@ -520,6 +567,8 @@ def simple_vxlanv6_packet(pktlen=300,
     @param ipv6_dst IPv6 destination
     @param ipv6_fl IPv6 flowlabel
     @param ipv6_tc IPv6 traffic class
+    @param ipv6_ecn IPv6 traffic class ECN
+    @param ipv6_dscp IPv6 traffic class DSCP
     @param ipv6_hlim IPv6 hop limit
     @param udp_sport UDP source port
     @param udp_dport UDP dest port (IANA) = 4789 (VxLAN)
@@ -539,6 +588,8 @@ def simple_vxlanv6_packet(pktlen=300,
         udp_hdr = scapy.UDP(sport=udp_sport, dport=udp_dport)
     else:
         udp_hdr = scapy.UDP(sport=udp_sport, dport=udp_dport, chksum=0)
+
+    ipv6_tc = ip_make_tos(ipv6_tc, ipv6_ecn, ipv6_dscp)
 
     # Note Dot1Q.id is really CFI
     if (dl_vlan_enable):
@@ -570,6 +621,8 @@ def simple_gre_packet(pktlen=300,
                       ip_src='192.168.0.1',
                       ip_dst='192.168.0.2',
                       ip_tos=0,
+                      ip_ecn=None,
+                      ip_dscp=None,
                       ip_ttl=64,
                       ip_id=0x0001,
                       ip_ihl=None,
@@ -599,6 +652,8 @@ def simple_gre_packet(pktlen=300,
     @param ip_src IP source
     @param ip_dst IP destination
     @param ip_tos IP ToS
+    @param ip_ecn IP ToS ECN
+    @param ip_dscp IP ToS DSCP
     @param ip_ttl IP TTL
     @param ip_id IP ID
     @param gre_chkum_present with or without checksum
@@ -629,6 +684,8 @@ def simple_gre_packet(pktlen=300,
                         flags=gre_flags, version=gre_version,
                         offset=gre_offset, key=gre_key,
                         seqence_number=gre_sequence_number) # typo in Scapy
+
+    ip_tos = ip_make_tos(ip_tos, ip_ecn, ip_dscp)
 
     # Note Dot1Q.id is really CFI
     if (dl_vlan_enable):
@@ -667,6 +724,8 @@ def simple_grev6_packet(pktlen=300,
                         ipv6_dst='3::4',
                         ipv6_fl=0,
                         ipv6_tc=0,
+                        ipv6_ecn=None,
+                        ipv6_dscp=None,
                         ipv6_hlim=64,
                         gre_chksum_present=0,
                         gre_routing_present=0, # begin reserved0
@@ -694,6 +753,8 @@ def simple_grev6_packet(pktlen=300,
     @param ipv6_dst IPv6 destination
     @param ipv6_fl IPv6 flowlabel
     @param ipv6_tc IPv6 traffic class
+    @param ipv6_ecn IPv6 traffic class ECN
+    @param ipv6_dscp IPv6 traffic class DSCP
     @param ipv6_hlim IPv6 hop limit
     @param gre_chkum_present with or without checksum
     @param gre_routing_present
@@ -723,6 +784,8 @@ def simple_grev6_packet(pktlen=300,
                         flags=gre_flags, version=gre_version,
                         offset=gre_offset, key=gre_key,
                         seqence_number=gre_sequence_number) # typo in Scapy
+
+    ipv6_tc = ip_make_tos(ipv6_tc, ipv6_ecn, ipv6_dscp)
 
     # Note Dot1Q.id is really CFI
     if (dl_vlan_enable):
@@ -755,6 +818,8 @@ def simple_gre_erspan_packet(pktlen=300,
                              ip_src='192.168.0.1',
                              ip_dst='192.168.0.2',
                              ip_tos=0,
+                             ip_ecn=None,
+                             ip_dscp=None,
                              ip_ttl=64,
                              ip_id=0x0001,
                              ip_ihl=None,
@@ -790,6 +855,8 @@ def simple_gre_erspan_packet(pktlen=300,
     @param ip_src IP source
     @param ip_dst IP destination
     @param ip_tos IP ToS
+    @param ip_ecn IP ToS ECN
+    @param ip_dscp IP ToS DSCP
     @param ip_ttl IP TTL
     @param ip_id IP ID
     @param gre_chkum_present with or without checksum
@@ -837,6 +904,8 @@ def simple_gre_erspan_packet(pktlen=300,
                               span_id = erspan_span_id,
                               unknown7 = erspan_unknown7)
 
+    ip_tos = ip_make_tos(ip_tos, ip_ecn, ip_dscp)
+
     # Note Dot1Q.id is really CFI
     if (dl_vlan_enable):
         pkt = scapy.Ether(dst=eth_dst, src=eth_src)/ \
@@ -871,6 +940,8 @@ def ipv4_erspan_pkt(pktlen=350,
                       ip_src='192.168.0.1',
                       ip_dst='192.168.0.2',
                       ip_tos=0,
+                      ip_ecn=None,
+                      ip_dscp=None,
                       ip_ttl=64,
                       ip_id=0x0001,
                       ip_ihl=None,
@@ -893,6 +964,8 @@ def ipv4_erspan_pkt(pktlen=350,
     @param ip_src IP source
     @param ip_dst IP destination
     @param ip_tos IP ToS
+    @param ip_ecn IP ToS ECN
+    @param ip_dscp IP ToS DSCP
     @param ip_ttl IP TTL
     @param ip_id IP ID
     @param erspan version
@@ -910,6 +983,8 @@ def ipv4_erspan_pkt(pktlen=350,
         erspan_hdr = scapy.GRE(proto=0x22eb)/scapy.ERSPAN_III(span_id=mirror_id, sgt_other = sgt_other)
     else:
         erspan_hdr = scapy.GRE(proto=0x88be)/scapy.ERSPAN(span_id=mirror_id)
+
+    ip_tos = ip_make_tos(ip_tos, ip_ecn, ip_dscp)
 
     # Note Dot1Q.id is really CFI
     if (dl_vlan_enable):
@@ -945,6 +1020,8 @@ def ipv4_erspan_platform_pkt(pktlen=350,
                       ip_src='192.168.0.1',
                       ip_dst='192.168.0.2',
                       ip_tos=0,
+                      ip_ecn=None,
+                      ip_dscp=None,
                       ip_ttl=64,
                       ip_id=0x0001,
                       ip_ihl=None,
@@ -970,6 +1047,8 @@ def ipv4_erspan_platform_pkt(pktlen=350,
     @param ip_src IP source
     @param ip_dst IP destination
     @param ip_tos IP ToS
+    @param ip_ecn IP ToS ECN
+    @param ip_dscp IP ToS DSCP
     @param ip_ttl IP TTL
     @param ip_id IP ID
     @param erspan version
@@ -992,6 +1071,8 @@ def ipv4_erspan_platform_pkt(pktlen=350,
             erspan_hdr = erspan_hdr/scapy.PlatformSpecific(platf_id=platf_id, info1=info1, info2=info2)
     else:
         erspan_hdr = scapy.GRE(proto=0x88be)/scapy.ERSPAN(span_id=mirror_id)
+
+    ip_tos = ip_make_tos(ip_tos, ip_ecn, ip_dscp)
 
     # Note Dot1Q.id is really CFI
     if (dl_vlan_enable):
@@ -1026,6 +1107,8 @@ def simple_udpv6_packet(pktlen=100,
                         ipv6_src='2001:db8:85a3::8a2e:370:7334',
                         ipv6_dst='2001:db8:85a3::8a2e:370:7335',
                         ipv6_tc=0,
+                        ipv6_ecn=None,
+                        ipv6_dscp=None,
                         ipv6_hlim=64,
                         ipv6_fl=0,
                         udp_sport=1234,
@@ -1043,6 +1126,8 @@ def simple_udpv6_packet(pktlen=100,
     @param ipv6_src IPv6 source
     @param ipv6_dst IPv6 destination
     @param ipv6_tc IPv6 traffic class
+    @param ipv6_ecn IPv6 traffic class ECN
+    @param ipv6_dscp IPv6 traffic class DSCP
     @param ipv6_ttl IPv6 hop limit
     @param ipv6_fl IPv6 flow label
     @param udp_dport UDP destination port
@@ -1054,6 +1139,8 @@ def simple_udpv6_packet(pktlen=100,
 
     if MINSIZE > pktlen:
         pktlen = MINSIZE
+
+    ipv6_tc = ip_make_tos(ipv6_tc, ipv6_ecn, ipv6_dscp)
 
     pkt = scapy.Ether(dst=eth_dst, src=eth_src)
     if dl_vlan_enable or vlan_vid or vlan_pcp:
@@ -1074,6 +1161,8 @@ def simple_ipv4ip_packet(pktlen=300,
                          ip_src='192.168.0.1',
                          ip_dst='192.168.0.2',
                          ip_tos=0,
+                         ip_ecn=None,
+                         ip_dscp=None,
                          ip_ttl=64,
                          ip_id=0x0001,
                          ip_ihl=None,
@@ -1093,6 +1182,8 @@ def simple_ipv4ip_packet(pktlen=300,
     @param ip_src IP source
     @param ip_dst IP destination
     @param ip_tos IP ToS
+    @param ip_ecn IP ToS ECN
+    @param ip_dscp IP ToS DSCP
     @param ip_ttl IP TTL
     @param ip_id IP ID
     @param inner_frame payload of the packet
@@ -1102,6 +1193,8 @@ def simple_ipv4ip_packet(pktlen=300,
 
     if MINSIZE > pktlen:
         pktlen = MINSIZE
+
+    ip_tos = ip_make_tos(ip_tos, ip_ecn, ip_dscp)
 
     # Note Dot1Q.id is really CFI
     if (dl_vlan_enable):
@@ -1140,6 +1233,8 @@ def simple_ipv6ip_packet(pktlen=300,
                          ipv6_dst='3::4',
                          ipv6_fl=0,
                          ipv6_tc=0,
+                         ipv6_ecn=None,
+                         ipv6_dscp=None,
                          ipv6_hlim=64,
                          inner_frame=None
                        ):
@@ -1157,6 +1252,8 @@ def simple_ipv6ip_packet(pktlen=300,
     @param ipv6_dst IPv6 destination
     @param ipv6_fl IPv6 flowlabel
     @param ipv6_tc IPv6 traffic class
+    @param ipv6_ecn IPv6 traffic class ECN
+    @param ipv6_dscp IPv6 traffic class DSCP
     @param ipv6_hlim IPv6 hop limit
     @param inner_frame payload of the GRE packet
 
@@ -1165,6 +1262,8 @@ def simple_ipv6ip_packet(pktlen=300,
 
     if MINSIZE > pktlen:
         pktlen = MINSIZE
+
+    ipv6_tc = ip_make_tos(ipv6_tc, ipv6_ecn, ipv6_dscp)
 
     # Note Dot1Q.id is really CFI
     if (dl_vlan_enable):
@@ -1197,6 +1296,8 @@ def simple_icmp_packet(pktlen=60,
                       ip_src='192.168.0.1',
                       ip_dst='192.168.0.2',
                       ip_tos=0,
+                      ip_ecn=None,
+                      ip_dscp=None,
                       ip_ttl=64,
                       ip_id=1,
                       icmp_type=8,
@@ -1215,6 +1316,8 @@ def simple_icmp_packet(pktlen=60,
     @param ip_src IP source
     @param ip_dst IP destination
     @param ip_tos IP ToS
+    @param ip_ecn IP ToS ECN
+    @param ip_dscp IP ToS DSCP
     @param ip_ttl IP TTL
     @param ip_id IP Identification
     @param icmp_type ICMP type
@@ -1228,6 +1331,8 @@ def simple_icmp_packet(pktlen=60,
 
     if MINSIZE > pktlen:
         pktlen = MINSIZE
+
+    ip_tos = ip_make_tos(ip_tos, ip_ecn, ip_dscp)
 
     if (dl_vlan_enable):
         pkt = scapy.Ether(dst=eth_dst, src=eth_src)/ \
@@ -1252,6 +1357,8 @@ def simple_icmpv6_packet(pktlen=100,
                          ipv6_src='2001:db8:85a3::8a2e:370:7334',
                          ipv6_dst='2001:db8:85a3::8a2e:370:7335',
                          ipv6_tc=0,
+                         ipv6_ecn=None,
+                         ipv6_dscp=None,
                          ipv6_hlim=64,
                          ipv6_fl=0,
                          icmp_type=8,
@@ -1269,6 +1376,8 @@ def simple_icmpv6_packet(pktlen=100,
     @param ipv6_src IPv6 source
     @param ipv6_dst IPv6 destination
     @param ipv6_tc IPv6 traffic class
+    @param ipv6_ecn IPv6 traffic class ECN
+    @param ipv6_dscp IPv6 traffic class DSCP
     @param ipv6_ttl IPv6 hop limit
     @param ipv6_fl IPv6 flow label
     @param icmp_type ICMP type
@@ -1280,6 +1389,8 @@ def simple_icmpv6_packet(pktlen=100,
 
     if MINSIZE > pktlen:
         pktlen = MINSIZE
+
+    ipv6_tc = ip_make_tos(ipv6_tc, ipv6_ecn, ipv6_dscp)
 
     pkt = scapy.Ether(dst=eth_dst, src=eth_src)
     if dl_vlan_enable or vlan_vid or vlan_pcp:
@@ -1355,6 +1466,8 @@ def simple_ip_packet(pktlen=100,
                      ip_src='192.168.0.1',
                      ip_dst='192.168.0.2',
                      ip_tos=0,
+                     ip_ecn=None,
+                     ip_dscp=None,
                      ip_ttl=64,
                      ip_id=0x0001,
                      ip_ihl=None,
@@ -1374,6 +1487,8 @@ def simple_ip_packet(pktlen=100,
     @param ip_src IP source
     @param ip_dst IP destination
     @param ip_tos IP ToS
+    @param ip_ecn IP ToS ECN
+    @param ip_dscp IP ToS DSCP
     @param ip_ttl IP TTL
     @param ip_id IP ID
 
@@ -1384,6 +1499,8 @@ def simple_ip_packet(pktlen=100,
 
     if MINSIZE > pktlen:
         pktlen = MINSIZE
+
+    ip_tos = ip_make_tos(ip_tos, ip_ecn, ip_dscp)
 
     # Note Dot1Q.id is really CFI
     if (dl_vlan_enable):
@@ -1406,6 +1523,8 @@ def simple_ip_only_packet(pktlen=100,
                      ip_src='192.168.0.1',
                      ip_dst='192.168.0.2',
                      ip_tos=0,
+                     ip_ecn=None,
+                     ip_dscp=None,
                      ip_ttl=64,
                      ip_id=0x0001,
                      ip_ihl=None,
@@ -1423,6 +1542,8 @@ def simple_ip_only_packet(pktlen=100,
     @param ip_src IP source
     @param ip_dst IP destination
     @param ip_tos IP ToS
+    @param ip_ecn IP ToS ECN
+    @param ip_dscp IP ToS DSCP
     @param ip_ttl IP TTL
     @param ip_id IP ID
 
@@ -1438,6 +1559,8 @@ def simple_ip_only_packet(pktlen=100,
         tcp_hdr = scapy.TCP(sport=tcp_sport, dport=tcp_dport, flags=tcp_flags)
     else:
         tcp_hdr = scapy.TCP(sport=tcp_sport, dport=tcp_dport, flags=tcp_flags, chksum=0)
+
+    ip_tos = ip_make_tos(ip_tos, ip_ecn, ip_dscp)
 
     if not ip_options:
         pkt = scapy.IP(src=ip_src, dst=ip_dst, tos=ip_tos, ttl=ip_ttl, id=ip_id, ihl=ip_ihl) / tcp_hdr
@@ -1519,6 +1642,8 @@ def simple_qinq_tcp_packet(pktlen=100,
                     ip_src='192.168.0.1',
                     ip_dst='192.168.0.2',
                     ip_tos=0,
+                    ip_ecn=None,
+                    ip_dscp=None,
                     ip_ttl=64,
                     tcp_sport=1234,
                     tcp_dport=80,
@@ -1541,6 +1666,8 @@ def simple_qinq_tcp_packet(pktlen=100,
     @param ip_src IP source
     @param ip_dst IP destination
     @param ip_tos IP ToS
+    @param ip_ecn IP ToS ECN
+    @param ip_dscp IP ToS DSCP
     @param tcp_dport TCP destination port
     @param ip_sport TCP source port
 
@@ -1551,6 +1678,8 @@ def simple_qinq_tcp_packet(pktlen=100,
 
     if MINSIZE > pktlen:
         pktlen = MINSIZE
+
+    ip_tos = ip_make_tos(ip_tos, ip_ecn, ip_dscp)
 
     # Note Dot1Q.id is really CFI
     pkt = scapy.Ether(dst=eth_dst, src=eth_src)/ \
@@ -1598,6 +1727,8 @@ def dhcp_offer_packet(eth_dst='00:01:02:03:04:05',
                 ip_dst='255.255.255.255',
                 ip_len=308,
                 ip_tos=16,
+                ip_ecn=None,
+                ip_dscp=None,
                 ip_ttl=128,
                 ip_id=0,
                 src_port=67,
@@ -1647,6 +1778,8 @@ def dhcp_offer_packet(eth_dst='00:01:02:03:04:05',
     @param padding '\x00' padding inserted at end of packet, '\x00'*n where n is number of bytes
     """
 
+    ip_tos = ip_make_tos(ip_tos, ip_ecn, ip_dscp)
+
     pkt = scapy.Ether(dst=eth_dst, src=eth_src)/ \
     scapy.IP(src=ip_src, dst=ip_dst, len=ip_len, tos=ip_tos, ttl=ip_ttl, id=0)/ \
     scapy.UDP(sport=src_port, dport=dst_port, len=udp_len)/ \
@@ -1693,6 +1826,8 @@ def dhcp_ack_packet(eth_dst='00:01:02:03:04:05',
                 ip_dst='255.255.255.255',
                 ip_len=328,
                 ip_tos=16,
+                ip_ecn=None,
+                ip_dscp=None,
                 ip_ttl=128,
                 ip_id=0,
                 src_port=67,
@@ -1741,6 +1876,8 @@ def dhcp_ack_packet(eth_dst='00:01:02:03:04:05',
     @param dhcp_netmask Subnet mask of client
     @param padding '\x00' padding inserted at end of packet, '\x00'*n where n is number of bytes
     """
+
+    ip_tos = ip_make_tos(ip_tos, ip_ecn, ip_dscp)
 
     pkt = scapy.Ether(dst=eth_dst, src=eth_src) / \
     scapy.IP(src=ip_src, dst=ip_dst, len=ip_len, tos=ip_tos, ttl=ip_ttl, id=ip_id) / \


### PR DESCRIPTION
Extend ip & ipv6 related packet creation functions with ecn & dscp
parameters, the reason for this is to simplify setting of these ToS/TC
fields w/o additional bitwise operations.

Added simple ip_make_tos(tos, ecn, dscp) helper which overwrites ip_tos/ipv6_tc
considering ecn & dscp values in every ip/ipv6 simple_xxx_packet function.

Signed-off-by: Vadim Kochan <vadymk@mellanox.com>