### PR TITLE
Catch exceptions when checkint interface status

### DIFF
--- a/ptf_nn/ptf_nn_agent.py
+++ b/ptf_nn/ptf_nn_agent.py
@@ -73,11 +73,16 @@ def set_if_status(iff, status):
     s.close()
 
 def get_if_status(iff):
-    s = socket.socket()
-    ifr = struct.pack('16sh', iff, 0)
-    result = ioctl(s, SIOCGIFFLAGS, ifr)
-    s.close()
+    try:
+        s = socket.socket()
+        ifr = struct.pack('16sh', iff, 0)
+        result = ioctl(s, SIOCGIFFLAGS, ifr)
+        s.close()
+    except IOError:
+        return False
+
     flags = struct.unpack('16sh', result)[1]
+
     return flags & IFF_UP > 0
 
 def if_exists(iff):


### PR DESCRIPTION
Sometimes an interface is presented in /sys/class/net hierarchy, but OS returns an error when we check a status of the interface.  When we have such error it means the interface is not ready yet, so we return False from get_if_status() function