### PR TITLE
Improve test failure messages

### DIFF
--- a/example/mytests/switch.py
+++ b/example/mytests/switch.py
@@ -34,7 +34,7 @@ table_attr_list = []
 
 def verify_packet_list_any(test, pkt_list,  ofport_list):
     logging.debug("Checking for packet on given ports")
-    (rcv_port, rcv_pkt, pkt_time) = test.dataplane.poll(timeout=1)
+    (rcv_device, rcv_port, rcv_pkt, pkt_time) = test.dataplane.poll(timeout=1)
     test.assertTrue(rcv_pkt != None, "No packet received")
 
     i = 0


### PR DESCRIPTION
Debugging PTF test failures can currently be quite painful, because the messages printed when tests fail aren't very informative. It would be better to print much more information in the case of a test failure, and to print this information all the time (rather than merely when debug logging is on) so that it is reported on CI infrastructure.

This PR adds code to display information about the packets we expected and the packets we actually received when tests fail, in the spirit of @jklr's PR #27.

One concern about the patch in #27 was that it reported this information in the `DataPlane` polling code, which isn't a good fit since we have a variety of `verify*()` functions with very different expectations. For example, `verify_packet_any_port()` can poll on many ports, and the test passes as long as the expected packet is received on at least one of them; that's information that `poll()` doesn't have. This PR avoids that issue by not printing any failure or logging messages inside `poll()`; instead, the objects returned from `poll()` are augmented with additional metadata that lets callers print nicer messages if they so choose.

In particular, `poll()` now returns a `namedtuple` of either `PollSuccess` or `PollFailure` type. Both can be destructed into the same fields that the old version of `poll()` returned, so existing code shouldn't need to change. However, callers can also access the fields by name (the usual advantage of `namedtuple`) and some additional metadata is available - `PollFailure` objects include a few recently received packets as well as a copy of the expected packet that we couldn't match.

`PollSuccess` and `PollFailure` also include a `format()` method that returns a string containing detailed information about the failure. I've updated the implementation of the `verify*()` functions to use `format()`. `format()` reports both the expected packet and recent non-matching packets. If the expected packet is a scapy `Packet` object, it's used as a dissector, both for itself and for the non-matching packets. (The approach I've used for the non-matching packets is a trick I learned from @xiaozhou.) A hex dump of the packets, in a convenient and readable format provided by scapy, is also included.

The resulting error messages are verbose, but they're only printed when tests fail, and I'd argue that we pretty much always want this kind of detailed information when tests fail. For that reason, I have not implemented any option to disable this feature. If there are special cases where specific tests don't want it (which I anticipate to be a rare need) they can call `DataPlane.poll()` or `dp_poll()` directly and use the result just as before, providing their own assertions.

Here's an example of the output when a `verify_packet()` test fails:

```
======================================================================
FAIL: test.MirrorTest
----------------------------------------------------------------------
Traceback (most recent call last):
  File "ptf-tests/parser_mirror/test.py", line 112, in runTest
    verify_packet(self, exp_pkt_mirror, mirror_port)
  File "/p4factory/install/lib/python2.7/site-packages/ptf/testutils.py", line 2226, in verify_packet
    % (device, port, result.format()))
AssertionError: Expected packet was not received on device 0, port 3.
========== EXPECTED ==========
dst        : DestMACField         = '11:11:11:11:11:11' (None)
src        : SourceMACField       = 'aa:ee:cc:dd:ee:ff' (None)
type       : XShortEnumField      = 33024           (0)
--
prio       : BitField             = 0               (0)
id         : BitField             = 0               (0)
vlan       : BitField             = 1               (1)
type       : XShortEnumField      = 2048            (0)
--
version    : BitField             = 4               (4)
ihl        : BitField             = None            (None)
tos        : XByteField           = 0               (0)
len        : ShortField           = None            (None)
id         : ShortField           = 1               (1)
flags      : FlagsField           = 0               (0)
frag       : BitField             = 0               (0)
ttl        : ByteField            = 64              (64)
proto      : ByteEnumField        = 6               (0)
chksum     : XShortField          = None            (None)
src        : Emph                 = '192.168.0.1'   (None)
dst        : Emph                 = '192.168.0.2'   ('127.0.0.1')
options    : PacketListField      = []              ([])
--
sport      : ShortEnumField       = 1234            (20)
dport      : ShortEnumField       = 80              (80)
seq        : IntField             = 0               (0)
ack        : IntField             = 0               (0)
dataofs    : BitField             = None            (None)
reserved   : BitField             = 0               (0)
flags      : FlagsField           = 2               (2)
window     : ShortField           = 8192            (8192)
chksum     : XShortField          = None            (None)
urgptr     : ShortField           = 0               (0)
options    : TCPOptionsField      = {}              ({})
--
load       : StrField             = '\x00\x01\x02\x03\x04\x05\x06\x07\x08\t\n\x0b\x0c\r\x0e\x0f\x10\x11\x12\x13\x14\x15\x16\x17\x18\x19\x1a\x1b\x1c\x1d\x1e\x1f !"#$%&\'()' ('')
--
0000   11 11 11 11 11 11 AA EE  CC DD EE FF 81 00 00 01   ................
0010   08 00 45 00 00 52 00 01  00 00 40 06 F9 51 C0 A8   ..E..R....@..Q..
0020   00 01 C0 A8 00 02 04 D2  00 50 00 00 00 00 00 00   .........P......
0030   00 00 50 02 20 00 63 88  00 00 00 01 02 03 04 05   ..P. .c.........
0040   06 07 08 09 0A 0B 0C 0D  0E 0F 10 11 12 13 14 15   ................
0050   16 17 18 19 1A 1B 1C 1D  1E 1F 20 21 22 23 24 25   .......... !"#$%
0060   26 27 28 29                                        &'()
========== RECEIVED ==========
1 total packets. Displaying most recent 1 packets:
------------------------------
dst        : DestMACField         = '11:11:11:11:11:11' (None)
src        : SourceMACField       = 'aa:bb:cc:dd:ee:ff' (None)
type       : XShortEnumField      = 33024           (0)
--
prio       : BitField             = 0L              (0)
id         : BitField             = 0L              (0)
vlan       : BitField             = 1L              (1)
type       : XShortEnumField      = 2048            (0)
--
version    : BitField             = 4L              (4)
ihl        : BitField             = 5L              (None)
tos        : XByteField           = 0               (0)
len        : ShortField           = 82              (None)
id         : ShortField           = 1               (1)
flags      : FlagsField           = 0L              (0)
frag       : BitField             = 0L              (0)
ttl        : ByteField            = 64              (64)
proto      : ByteEnumField        = 6               (0)
chksum     : XShortField          = 63825           (None)
src        : Emph                 = '192.168.0.1'   (None)
dst        : Emph                 = '192.168.0.2'   ('127.0.0.1')
options    : PacketListField      = []              ([])
--
sport      : ShortEnumField       = 1234            (20)
dport      : ShortEnumField       = 80              (80)
seq        : IntField             = 0               (0)
ack        : IntField             = 0               (0)
dataofs    : BitField             = 5L              (None)
reserved   : BitField             = 0L              (0)
flags      : FlagsField           = 2L              (2)
window     : ShortField           = 8192            (8192)
chksum     : XShortField          = 25480           (None)
urgptr     : ShortField           = 0               (0)
options    : TCPOptionsField      = []              ({})
--
load       : StrField             = '\x00\x01\x02\x03\x04\x05\x06\x07\x08\t\n\x0b\x0c\r\x0e\x0f\x10\x11\x12\x13\x14\x15\x16\x17\x18\x19\x1a\x1b\x1c\x1d\x1e\x1f !"#$%&\'()' ('')
--
0000   11 11 11 11 11 11 AA BB  CC DD EE FF 81 00 00 01   ................
0010   08 00 45 00 00 52 00 01  00 00 40 06 F9 51 C0 A8   ..E..R....@..Q..
0020   00 01 C0 A8 00 02 04 D2  00 50 00 00 00 00 00 00   .........P......
0030   00 00 50 02 20 00 63 88  00 00 00 01 02 03 04 05   ..P. .c.........
0040   06 07 08 09 0A 0B 0C 0D  0E 0F 10 11 12 13 14 15   ................
0050   16 17 18 19 1A 1B 1C 1D  1E 1F 20 21 22 23 24 25   .......... !"#$%
0060   26 27 28 29                                        &'()
==============================
```

I've found the output that this PR generates makes my life *much* easier when debugging failing PTF tests, and I'm sure others will as well.