### PR TITLE
[ptf_nn_agent]: Don't start Nanomsg sockets until all Ifaces are up

### DIFF
--- a/ptf_nn/ptf_nn_agent.py
+++ b/ptf_nn/ptf_nn_agent.py
@@ -386,8 +386,11 @@ def main():
 
     # Wait until all interfaces are up and ready
     for iface in iface_mgrs.values():
-        if not iface.is_ready():
-            time.sleep(1)
+        while True:
+          if iface.is_ready():
+              break
+          else:
+              time.sleep(1)
 
     for dev, addr in args.device_sockets:
         n = NanomsgMgr(dev, addr, args.nn_rcv_buf, args.nn_snd_buf)


### PR DESCRIPTION
Otherwise ptf_nn_agent could crash if Nanomsg socket receives a packet to send, but an Interface which will be used to send the packet is still not ready to send it