### PR TITLE
[TestUtils]: fix the issue of verify_packet_any_port

### DIFF
--- a/src/ptf/testutils.py
+++ b/src/ptf/testutils.py
@@ -2356,7 +2356,7 @@ def verify_packet_any_port(test, pkt, ports=[], device_number=0):
     Returns the index of the port on which the packet is received and the packet.
     """
     logging.debug("Checking for pkt on device %d, port %r", device_number, ports)
-    result = dp_poll(test, device_number=device_number, exp_pkt=pkt, timeout=1)
+    result = dp_poll(test, device_number=device_number, exp_pkt=pkt, timeout=1, port_number= ports)
     verify_no_other_packets(test, device_number=device_number)
 
     if isinstance(result, test.dataplane.PollSuccess):


### PR DESCRIPTION
Failing to include port_number when calling dp_poll in verify_packet_any_port, will result in dataplane warning as follows: 

"dataplane : WARNING : Dataplane poll with exp_pkt but no port number " 