### PR TITLE
Fix verify_any_packet_any_port implementation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,12 @@ language: generic
 
 dist: trusty
 
+# New travis trusty images give me Python import errors for nnpy, forcing use of
+# the old ones for now. These will be deprecated in September. Either this issue
+# will be resolved before then or I will have to run the tests in a docker
+# image.
+group: deprecated-2017Q3
+
 # My very smart trick to force inclusion of the veth kernel module
 # (even though we do not use docker at all her)
 services:

--- a/ptf_nn/ptf_nn_test/test.py
+++ b/ptf_nn/ptf_nn_test/test.py
@@ -75,3 +75,23 @@ class GetCountersTest(DataplaneBaseTest):
         print " (1, 1) %d:%d" % counters_11_e
         self.assertTrue(counters_01_e[1] > counters_01_b[1])
         self.assertTrue(counters_11_e[0] > counters_11_b[0])
+
+class VerifyAnyPacketAnyPort(DataplaneBaseTest):
+    def __init__(self):
+        DataplaneBaseTest.__init__(self)
+
+    def runTest(self):
+        pkt = "ab" * 20
+
+        testutils.send_packet(self, (0, 1), str(pkt))
+        print "packet sent"
+        testutils.verify_any_packet_any_port(
+            self, pkts=[pkt], ports=[3, 1], device_number=1)
+
+        # negative test: if the packet is indeed received, but not on one of the
+        # expected ports, the test should fail
+        with self.assertRaises(AssertionError):
+            testutils.send_packet(self, (0, 1), str(pkt))
+            print "packet sent"
+            testutils.verify_any_packet_any_port(
+                self, pkts=[pkt], ports=[0, 2, 3], device_number=1)

--- a/src/ptf/testutils.py
+++ b/src/ptf/testutils.py
@@ -2400,6 +2400,11 @@ def verify_any_packet_any_port(test, pkts=[], ports=[], device_number=0):
     if isinstance(result, test.dataplane.PollFailure):
         test.fail("Did not receive any expected packet on any of ports %r for "
                   "device %d.\n%s" % (ports, device_number, result.format()))
+
+    if result.port not in ports:
+        test.fail("One of the expected packets was received on device %d on an "
+                  "unexpected port: %d\n%s" % (device_number, result.port, result.format()))
+
     return match_index
 
 def verify_each_packet_on_each_port(test, pkts=[], ports=[], device_number=0):


### PR DESCRIPTION
There was a bug: if one of the expected packets was received on an
unexpected port, the function would not raise an error.