### PR TITLE
fix mask packet comparison

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open('README.md') as readme_file:
 
 setup(
     name='ptf',
-    version='0.9',
+    version='0.9.1',
     description='PTF is a Python based dataplane test framework.',
     long_description=readme,
     author='Antonin Bas',

--- a/src/ptf/mask.py
+++ b/src/ptf/mask.py
@@ -4,11 +4,12 @@ from scapy.utils import hexdump
 import packet as scapy
 
 class Mask:
-    def __init__(self, exp_pkt):
+    def __init__(self, exp_pkt, ignore_extra_bytes=False):
         self.exp_pkt = exp_pkt
         self.size = len(str(exp_pkt))
         self.valid = True
         self.mask = [0xff] * self.size
+        self.ignore_extra_bytes = ignore_extra_bytes
 
 
     def set_do_not_care(self, offset, bitwidth):
@@ -44,15 +45,19 @@ class Mask:
                 offset += bits
         self.set_do_not_care(hdr_offset * 8 + offset, bitwidth)
 
+    def set_ignore_extra_bytes():
+        self.ignore_extra_bytes = True
+
     def is_valid(self):
         return self.valid
 
     def pkt_match(self, pkt):
         # just to be on the safe side
         pkt = str(pkt)
-        # we compare up to the expected size, and fail if we haven't
-        # received enough bits
-        if len(pkt) < self.size:
+        # we fail if we don't match on sizes, or if ignore_extra_bytes is set,
+        # fail if we have not received at least size bytes
+        if len(pkt) != self.size or \
+           (self.ignore_extra_bytes and len(pkt) < self.size):
             return False
         exp_pkt = str(self.exp_pkt)
         for i in xrange(self.size):

--- a/src/ptf/mask.py
+++ b/src/ptf/mask.py
@@ -62,6 +62,7 @@ class Mask:
 
     def __str__(self):
         assert(self.valid)
+        old_stdout = sys.stdout
         sys.stdout = buffer = StringIO()
         hexdump(self.exp_pkt)
         print 'mask =',
@@ -70,7 +71,7 @@ class Mask:
             print ' '.join('%02x' % (x) for x in self.mask[i : i+8]),
             print ' ',
             print ' '.join('%02x' % (x) for x in self.mask[i+8 : i+16])
-        sys.stdout = sys.__stdout__
+        sys.stdout = old_stdout
         return buffer.getvalue()
 def utest():
     p = scapy.Ether() / scapy.IP() / scapy.TCP()

--- a/src/ptf/mask.py
+++ b/src/ptf/mask.py
@@ -78,6 +78,7 @@ class Mask:
             print ' '.join('%02x' % (x) for x in self.mask[i+8 : i+16])
         sys.stdout = old_stdout
         return buffer.getvalue()
+
 def utest():
     p = scapy.Ether() / scapy.IP() / scapy.TCP()
     m = Mask(p)

--- a/src/ptf/packet.py
+++ b/src/ptf/packet.py
@@ -16,7 +16,7 @@ try:
     import scapy.layers.dhcp
     import scapy.packet
     import scapy.main
-    if not config.has_key("disable_ipv6"):
+    if "disable_ipv6" not in config:
         import scapy.route6
         import scapy.layers.inet6
 except ImportError:
@@ -37,14 +37,14 @@ DHCP = scapy.layers.dhcp.DHCP
 BOOTP = scapy.layers.dhcp.BOOTP
 PADDING = scapy.packet.Padding
 
-if not config.has_key("disable_ipv6"):
+if "disable_ipv6" not in config:
     IPv6 = scapy.layers.inet6.IPv6
     IPv6ExtHdrRouting = scapy.layers.inet6.IPv6ExtHdrRouting
     ICMPv6Unknown = scapy.layers.inet6.ICMPv6Unknown
     ICMPv6EchoRequest = scapy.layers.inet6.ICMPv6EchoRequest
 
 VXLAN = None
-if not config.has_key("disable_vxlan"):
+if "disable_vxlan" not in config:
     try:
         scapy.main.load_contrib("vxlan")
         VXLAN = scapy.contrib.vxlan.VXLAN
@@ -56,7 +56,7 @@ if not config.has_key("disable_vxlan"):
 ERSPAN = None
 ERSPAN_III = None
 PlatformSpecific = None
-if not config.has_key("disable_erspan"):
+if "disable_erspan" not in config:
     try:
         scapy.main.load_contrib("erspan")
         ERSPAN = scapy.contrib.erspan.ERSPAN
@@ -68,7 +68,7 @@ if not config.has_key("disable_erspan"):
         pass
 
 GENEVE = None
-if not config.has_key("disable_geneve"):
+if "disable_geneve" not in config:
     try:
         scapy.main.load_contrib("geneve")
         GENEVE = scapy.contrib.geneve.GENEVE
@@ -78,7 +78,7 @@ if not config.has_key("disable_geneve"):
         pass
 
 MPLS = None
-if not config.has_key("disable_mpls"):
+if "disable_mpls" not in config:
     try:
         scapy.main.load_contrib("mpls")
         MPLS = scapy.contrib.mpls.MPLS
@@ -88,7 +88,7 @@ if not config.has_key("disable_mpls"):
         pass
 
 NVGRE = None
-if not config.has_key("disable_nvgre"):
+if "disable_nvgre" not in config:
     try:
         scapy.main.load_contrib("nvgre")
         NVGRE = scapy.contrib.nvgre.NVGRE

--- a/src/ptf/packet.py
+++ b/src/ptf/packet.py
@@ -16,7 +16,7 @@ try:
     import scapy.layers.dhcp
     import scapy.packet
     import scapy.main
-    if "disable_ipv6" not in config:
+    if not config.get("disable_ipv6", False):
         import scapy.route6
         import scapy.layers.inet6
 except ImportError:
@@ -37,14 +37,14 @@ DHCP = scapy.layers.dhcp.DHCP
 BOOTP = scapy.layers.dhcp.BOOTP
 PADDING = scapy.packet.Padding
 
-if "disable_ipv6" not in config:
+if not config.get("disable_ipv6", False):
     IPv6 = scapy.layers.inet6.IPv6
     IPv6ExtHdrRouting = scapy.layers.inet6.IPv6ExtHdrRouting
     ICMPv6Unknown = scapy.layers.inet6.ICMPv6Unknown
     ICMPv6EchoRequest = scapy.layers.inet6.ICMPv6EchoRequest
 
 VXLAN = None
-if "disable_vxlan" not in config:
+if not config.get("disable_vxlan", False):
     try:
         scapy.main.load_contrib("vxlan")
         VXLAN = scapy.contrib.vxlan.VXLAN
@@ -56,7 +56,7 @@ if "disable_vxlan" not in config:
 ERSPAN = None
 ERSPAN_III = None
 PlatformSpecific = None
-if "disable_erspan" not in config:
+if not config.get("disable_erspan", False):
     try:
         scapy.main.load_contrib("erspan")
         ERSPAN = scapy.contrib.erspan.ERSPAN
@@ -68,7 +68,7 @@ if "disable_erspan" not in config:
         pass
 
 GENEVE = None
-if "disable_geneve" not in config:
+if not config.get("disable_geneve", False):
     try:
         scapy.main.load_contrib("geneve")
         GENEVE = scapy.contrib.geneve.GENEVE
@@ -78,7 +78,7 @@ if "disable_geneve" not in config:
         pass
 
 MPLS = None
-if "disable_mpls" not in config:
+if not config.get("disable_mpls", False):
     try:
         scapy.main.load_contrib("mpls")
         MPLS = scapy.contrib.mpls.MPLS
@@ -88,7 +88,7 @@ if "disable_mpls" not in config:
         pass
 
 NVGRE = None
-if "disable_nvgre" not in config:
+if not config.get("disable_nvgre", False):
     try:
         scapy.main.load_contrib("nvgre")
         NVGRE = scapy.contrib.nvgre.NVGRE

--- a/src/ptf/packet.py
+++ b/src/ptf/packet.py
@@ -16,7 +16,7 @@ try:
     import scapy.layers.dhcp
     import scapy.packet
     import scapy.main
-    if not config["disable_ipv6"]:
+    if not config.has_key("disable_ipv6"):
         import scapy.route6
         import scapy.layers.inet6
 except ImportError:
@@ -37,14 +37,14 @@ DHCP = scapy.layers.dhcp.DHCP
 BOOTP = scapy.layers.dhcp.BOOTP
 PADDING = scapy.packet.Padding
 
-if not config["disable_ipv6"]:
+if not config.has_key("disable_ipv6"):
     IPv6 = scapy.layers.inet6.IPv6
     IPv6ExtHdrRouting = scapy.layers.inet6.IPv6ExtHdrRouting
     ICMPv6Unknown = scapy.layers.inet6.ICMPv6Unknown
     ICMPv6EchoRequest = scapy.layers.inet6.ICMPv6EchoRequest
 
 VXLAN = None
-if not config["disable_vxlan"]:
+if not config.has_key("disable_vxlan"):
     try:
         scapy.main.load_contrib("vxlan")
         VXLAN = scapy.contrib.vxlan.VXLAN
@@ -56,7 +56,7 @@ if not config["disable_vxlan"]:
 ERSPAN = None
 ERSPAN_III = None
 PlatformSpecific = None
-if not config["disable_erspan"]:
+if not config.has_key("disable_erspan"):
     try:
         scapy.main.load_contrib("erspan")
         ERSPAN = scapy.contrib.erspan.ERSPAN
@@ -68,7 +68,7 @@ if not config["disable_erspan"]:
         pass
 
 GENEVE = None
-if not config["disable_geneve"]:
+if not config.has_key("disable_geneve"):
     try:
         scapy.main.load_contrib("geneve")
         GENEVE = scapy.contrib.geneve.GENEVE
@@ -78,7 +78,7 @@ if not config["disable_geneve"]:
         pass
 
 MPLS = None
-if not config["disable_mpls"]:
+if not config.has_key("disable_mpls"):
     try:
         scapy.main.load_contrib("mpls")
         MPLS = scapy.contrib.mpls.MPLS
@@ -88,7 +88,7 @@ if not config["disable_mpls"]:
         pass
 
 NVGRE = None
-if not config["disable_nvgre"]:
+if not config.has_key("disable_nvgre"):
     try:
         scapy.main.load_contrib("nvgre")
         NVGRE = scapy.contrib.nvgre.NVGRE


### PR DESCRIPTION
pkt_match was strictly comparing the length of the packet argument with the size of the mask. It is desirable to compare only the prefix given by the mask.size. Also fixed the printing of masks to match how we print packet output using hexdump -- it captures the print output in a buffer that is then returned.

Replace the direct check of `not config['key']` with `not config.has_key('key')` to avoid throwing an exception when importing packet directly.

And finally, bump the version to 0.9.1