### PR TITLE
 Print aligned hex dump in assertion

### DIFF
--- a/src/ptf/dataplane.py
+++ b/src/ptf/dataplane.py
@@ -816,7 +816,7 @@ class DataPlane(Thread):
                         print '--'
                         scapy.utils.hexdump(self.expected_packet)
                     elif isinstance(self.expected_packet, mask.Mask):
-                        print 'Mask:', str(self.expected_packet)
+                        print 'Mask:\n', str(self.expected_packet)
                     else:
                         scapy.utils.hexdump(self.expected_packet)
 

--- a/src/ptf/mask.py
+++ b/src/ptf/mask.py
@@ -45,7 +45,7 @@ class Mask:
                 offset += bits
         self.set_do_not_care(hdr_offset * 8 + offset, bitwidth)
 
-    def set_ignore_extra_bytes():
+    def set_ignore_extra_bytes(self):
         self.ignore_extra_bytes = True
 
     def is_valid(self):

--- a/src/ptf/mask.py
+++ b/src/ptf/mask.py
@@ -74,7 +74,7 @@ class Mask:
         for i in range(0, len(self.mask), 16):
             if i > 0: print '%04x  ' % i,
             print ' '.join('%02x' % (x) for x in self.mask[i : i+8]),
-            print ' ',
+            print '',
             print ' '.join('%02x' % (x) for x in self.mask[i+8 : i+16])
         sys.stdout = old_stdout
         return buffer.getvalue()


### PR DESCRIPTION
This only affects hex dumps for masked packets. Before this fix, it printed:

    ========== EXPECTED ==========
    Mask: 0000   00 11 22 33 44 55 00 0A  0B 0C 0D 0E 08 00 45 00   .."3DU........E.
    0010   00 20 00 01 00 00 40 11  F9 78 C0 A8 00 01 C0 A8   . ....@..x......
    0020   00 02 04 D2 10 E1 00 0C  00 00 00 00 01 00         ..............



With this fix there's a newline after `Mask:`:

    ========== EXPECTED ==========
    Mask:
    0000   00 11 22 33 44 55 00 0A  0B 0C 0D 0E 08 00 45 00   .."3DU........E.
    0010   00 20 00 01 00 00 40 11  F9 78 C0 A8 00 01 C0 A8   . ....@..x......
    0020   00 02 04 D2 10 E1 00 0C  00 00 00 00 01 00         ..............

