### PR TITLE
[TestUtils]:Support creat eth and tcp packets with a tag list

### DIFF
--- a/src/ptf/testutils.py
+++ b/src/ptf/testutils.py
@@ -62,6 +62,98 @@ def ip_make_tos(tos, ecn, dscp):
 
     return tos
 
+def simple_tcp_packet_ext_taglist(pktlen=100,
+                                  eth_dst='00:01:02:03:04:05',
+                                  eth_src='00:06:07:08:09:0a',
+                                  dl_taglist_enable=False,
+                                  dl_vlan_pcp_list=[0],
+                                  dl_vlan_cfi_list=[0],
+                                  dl_tpid_list=[0x8100],
+                                  dl_vlanid_list=[1],
+                                  ip_src='192.168.0.1',
+                                  ip_dst='192.168.0.2',
+                                  ip_tos=0,
+                                  ip_ecn=None,
+                                  ip_dscp=None,
+                                  ip_ttl=64,
+                                  ip_id=0x0001,
+                                  ip_frag=0,
+                                  tcp_sport=1234,
+                                  tcp_dport=80,
+                                  tcp_flags="S",
+                                  ip_ihl=None,
+                                  ip_options=False,
+                                  with_tcp_chksum=True
+                                  ):
+    """
+    Return a simple dataplane TCP packet without tag or with one or multiple tags
+    The size of the list of the argument "dl_vlan_pcp_list", "dl_vlan_cfi",
+    "dl_tpid_list" and "dl_vlanid_list" must be the same when "dl_taglist_enable" is True.
+
+    Supports a few parameters:
+    @param pktlen Length of packet in bytes w/o CRC
+    @param eth_dst Destinatino MAC
+    @param eth_src Source MAC
+    @param dl_taglist_enable False if no tag. True if the packet contains one or multiple tags.
+    @param dl_vlan_pcp_list VLAN priority list. Not used when dl_taglist_enable is False.
+    @param dl_vlan_cfi_list The VLAN CFI list. Not used when dl_taglist_enable is False.
+    @param dl_tpid_list The TPID list. Not used when dl_taglist_enable is False.
+    @param dl_vlanid_list The VLAN ID list. Not used when dl_taglist_enable is False.
+    @param ip_src IP source
+    @param ip_dst IP destination
+    @param ip_tos IP ToS
+    @param ip_ecn IP ToS ECN
+    @param ip_dscp IP ToS DSCP
+    @param ip_ttl IP TTL
+    @param ip_id IP ID
+    @param tcp_sport TCP source port
+    @param tcp_dport TCP destination port
+    @param tcp_flags TCP Control flags
+    @param with_tcp_chksum Valid TCP checksum
+
+    Generates a simple TCP request.  Users
+    shouldn't assume anything about this packet other than that
+    it is a valid ethernet/IP/TCP frame.
+    """
+
+    if MINSIZE > pktlen:
+        pktlen = MINSIZE
+
+    if with_tcp_chksum:
+        tcp_hdr = scapy.TCP(sport=tcp_sport, dport=tcp_dport, flags=tcp_flags)
+    else:
+        tcp_hdr = scapy.TCP(sport=tcp_sport, dport=tcp_dport, flags=tcp_flags, chksum=0)
+
+    ip_tos = ip_make_tos(ip_tos, ip_ecn, ip_dscp)
+
+    # Note Dot1Q.id is really CFI
+    if (dl_taglist_enable):
+        pkt = scapy.Ether(dst=eth_dst, src=eth_src)
+
+        for i in range(0, len(dl_vlanid_list)):
+            pkt = pkt/scapy.Dot1Q(prio=dl_vlan_pcp_list[i], id=dl_vlan_cfi_list[i], vlan=dl_vlanid_list[i])
+
+        pkt = pkt/scapy.IP(src=ip_src, dst=ip_dst, tos=ip_tos, ttl=ip_ttl, id=ip_id, ihl=ip_ihl)/ \
+              tcp_hdr
+
+        for i in range(1, len(dl_tpid_list)):
+            pkt[Dot1Q:i].type=dl_tpid_list[i]
+        pkt.type=dl_tpid_list[0]
+
+    else:
+        if not ip_options:
+            pkt = scapy.Ether(dst=eth_dst, src=eth_src)/ \
+                scapy.IP(src=ip_src, dst=ip_dst, tos=ip_tos, ttl=ip_ttl, id=ip_id, ihl=ip_ihl, frag=ip_frag)/ \
+                tcp_hdr
+        else:
+            pkt = scapy.Ether(dst=eth_dst, src=eth_src)/ \
+                scapy.IP(src=ip_src, dst=ip_dst, tos=ip_tos, ttl=ip_ttl, id=ip_id, ihl=ip_ihl, frag=ip_frag, options=ip_options)/ \
+                tcp_hdr
+
+    pkt = pkt/("".join([chr(x % 256) for x in xrange(pktlen - len(pkt))]))
+
+    return pkt
+
 def simple_tcp_packet(pktlen=100,
                       eth_dst='00:01:02:03:04:05',
                       eth_src='00:06:07:08:09:0a',
@@ -88,12 +180,13 @@ def simple_tcp_packet(pktlen=100,
     Return a simple dataplane TCP packet
 
     Supports a few parameters:
-    @param len Length of packet in bytes w/o CRC
+    @param pktlen Length of packet in bytes w/o CRC
     @param eth_dst Destinatino MAC
     @param eth_src Source MAC
     @param dl_vlan_enable True if the packet is with vlan, False otherwise
     @param vlan_vid VLAN ID
     @param vlan_pcp VLAN priority
+    @param dl_vlan_cfi The VLAN CFI value
     @param ip_src IP source
     @param ip_dst IP destination
     @param ip_tos IP ToS
@@ -111,34 +204,39 @@ def simple_tcp_packet(pktlen=100,
     it is a valid ethernet/IP/TCP frame.
     """
 
-    if MINSIZE > pktlen:
-        pktlen = MINSIZE
+    pcp_list = []
+    cfi_list = []
+    tpid_list = []
+    vlan_list = []
 
-    if with_tcp_chksum:
-        tcp_hdr = scapy.TCP(sport=tcp_sport, dport=tcp_dport, flags=tcp_flags)
-    else:
-        tcp_hdr = scapy.TCP(sport=tcp_sport, dport=tcp_dport, flags=tcp_flags, chksum=0)
-
-    ip_tos = ip_make_tos(ip_tos, ip_ecn, ip_dscp)
-
-    # Note Dot1Q.id is really CFI
     if (dl_vlan_enable):
-        pkt = scapy.Ether(dst=eth_dst, src=eth_src)/ \
-            scapy.Dot1Q(prio=vlan_pcp, id=dl_vlan_cfi, vlan=vlan_vid)/ \
-            scapy.IP(src=ip_src, dst=ip_dst, tos=ip_tos, ttl=ip_ttl, id=ip_id, ihl=ip_ihl)/ \
-            tcp_hdr
-    else:
-        if not ip_options:
-            pkt = scapy.Ether(dst=eth_dst, src=eth_src)/ \
-                scapy.IP(src=ip_src, dst=ip_dst, tos=ip_tos, ttl=ip_ttl, id=ip_id, ihl=ip_ihl, frag=ip_frag)/ \
-                tcp_hdr
-        else:
-            pkt = scapy.Ether(dst=eth_dst, src=eth_src)/ \
-                scapy.IP(src=ip_src, dst=ip_dst, tos=ip_tos, ttl=ip_ttl, id=ip_id, ihl=ip_ihl, frag=ip_frag, options=ip_options)/ \
-                tcp_hdr
+        pcp_list.append(vlan_pcp)
+        cfi_list.append(dl_vlan_cfi)
+        tpid_list.append(0x8100)
+        vlan_list.append(vlan_vid)
 
-    pkt = pkt/("".join([chr(x % 256) for x in xrange(pktlen - len(pkt))]))
-
+    pkt = simple_tcp_packet_ext_taglist(pktlen=pktlen,
+                                        eth_dst=eth_dst,
+                                        eth_src=eth_src,
+                                        dl_taglist_enable=dl_vlan_enable,
+                                        dl_vlan_pcp_list=pcp_list,
+                                        dl_vlan_cfi_list=cfi_list,
+                                        dl_tpid_list=tpid_list,
+                                        dl_vlanid_list=vlan_list,
+                                        ip_src=ip_src,
+                                        ip_dst=ip_dst,
+                                        ip_tos=ip_tos,
+                                        ip_ecn=ip_ecn,
+                                        ip_dscp=ip_dscp,
+                                        ip_ttl=ip_ttl,
+                                        ip_id=ip_id,
+                                        ip_frag=ip_frag,
+                                        tcp_sport=tcp_sport,
+                                        tcp_dport=tcp_dport,
+                                        tcp_flags=tcp_flags,
+                                        ip_ihl=ip_ihl,
+                                        ip_options = ip_options,
+                                        with_tcp_chksum = with_tcp_chksum)
     return pkt
 
 def simple_tcpv6_packet(pktlen=100,
@@ -1525,6 +1623,51 @@ def simple_eth_packet(pktlen=60,
 
     pkt = pkt/("0" * (pktlen - len(pkt)))
 
+    return pkt
+
+def simple_eth_raw_packet_with_taglist(pktlen=60,
+                                       eth_dst='00:01:02:03:04:05',
+                                       eth_src='00:06:07:08:09:0a',
+                                       dl_taglist_enable=False,
+                                       dl_vlan_pcp_list=[0],
+                                       dl_vlan_cfi_list=[0],
+                                       dl_tpid_list=[0x8100],
+                                       dl_vlanid_list=[1],
+                                       ):
+    """
+    Return a simple dataplane Layer 2 packet without tag or with one or multiple tags
+    The size of the list of the argument "dl_vlan_pcp_list", "dl_vlan_cfi",
+    "dl_tpid_list" and "dl_vlanid_list" must be the same when "dl_taglist_enable" is True.
+
+    Supports a few parameters:
+    @param pktlen Length of packet in bytes w/o CRC
+    @param eth_dst Destinatino MAC
+    @param eth_src Source MAC
+    @param dl_taglist_enable False if no tag. True if the packet contains one or multiple tags.
+    @param dl_vlan_pcp_list VLAN priority list. Not used when dl_taglist_enable is False.
+    @param dl_vlan_cfi_list The VLAN CFI list. Not used when dl_taglist_enable is False.
+    @param dl_tpid_list The TPID list. Not used when dl_taglist_enable is False.
+    @param dl_vlanid_list The VLAN ID list. Not used when dl_taglist_enable is False.
+
+    Generates a simple Layer 2 packet.
+    """
+
+    if MINSIZE > pktlen:
+        pktlen = MINSIZE
+
+    pkt = scapy.Ether(dst=eth_dst, src=eth_src)
+
+    if (dl_taglist_enable):
+        for i in range(0, len(dl_vlanid_list)):
+            pkt = pkt/scapy.Dot1Q(prio=dl_vlan_pcp_list[i], id=dl_vlan_cfi_list[i], vlan=dl_vlanid_list[i])
+
+        for i in range(1, len(dl_tpid_list)):
+            pkt[Dot1Q:i].type=dl_tpid_list[i]
+        pkt.type=dl_tpid_list[0]
+
+    # Fill payload length
+    pkt[Dot1Q:len(dl_tpid_list)].type = pktlen - len(pkt)
+    pkt = pkt/("".join([chr(x % 256) for x in xrange(pktlen - len(pkt))]))
     return pkt
 
 def simple_ip_packet(pktlen=100,


### PR DESCRIPTION
New API simple_tcp_packet_ext_taglist to create tcp packet with a tag list.
Let simple_tcp_packet invoke simple_tcp_packet_ext_taglist.
New API simple_eth_raw_packet_with_taglist to create eth packet with a tag list.
