### PR TITLE
Better --test-params handling

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 # Config file for automatic testing at travis-ci.org
 
+dist: xenial
+
 sudo: required
 
 # My very smart trick to force inclusion of the veth kernel module
@@ -14,15 +16,17 @@ addons:
       - python-pip
       - cmake
       - libffi-dev
+      - python3-dev
+      - python3-pip
 
 before_install:
   - sudo apt-get install ethtool
-  - sudo pip install --upgrade pip
   - sudo apt-get remove python-scapy
   - git clone https://github.com/p4lang/scapy-vxlan.git && cd scapy-vxlan && sudo python setup.py install && cd ..
   - bash CI/travis/install-nanomsg.sh
   - sudo ldconfig
   - bash CI/travis/install-nnpy.sh
+  - sudo pip3 install nose2
 
 install:
   - sudo python setup.py install
@@ -33,3 +37,4 @@ before_script:
 script:
   - python CI/travis/check-nnpy.py
   - ./CI/travis/run_tests.sh
+  - sudo python3 /usr/local/bin/nose2 utests.tests

--- a/CI/travis/install-nnpy.sh
+++ b/CI/travis/install-nnpy.sh
@@ -2,7 +2,7 @@
 set -e
 git clone https://github.com/nanomsg/nnpy.git
 cd nnpy
-sudo pip install cffi
-sudo pip install --upgrade cffi
-sudo pip install .
+sudo pip2 install cffi
+sudo pip2 install --upgrade cffi
+sudo pip2 install .
 cd ..

--- a/ptf
+++ b/ptf
@@ -79,7 +79,7 @@ config_default = {
 
     # Test behavior options
     "relax"              : False,
-    "test_params"        : "None",
+    "test_params"        : None,
     "failfast"           : False,
     "fail_skipped"       : False,
     "default_timeout"    : 2.0,
@@ -99,7 +99,7 @@ config_default = {
     "socket_recv_size"   : 4096,
 
     # Other configuration
-    "port_map"           : {},
+    "port_map"           : None,
 }
 
 def config_setup():
@@ -260,7 +260,7 @@ be subtracted from the result by prefixing them with the '^' character.  """
                       help="Relax packet match checks allowing other packets")
     group.add_argument("--failfast", action="store_true",
                       help="Stop running tests as soon as one fails")
-    test_params_help = """Set test parameters: key=val;... (see --list)
+    test_params_help = """Set test parameters: [key=val]*;key=val
     """
     group.add_argument("-t", "--test-params", help=test_params_help)
     group.add_argument("--fail-skipped", action="store_true",
@@ -482,7 +482,6 @@ def prune_tests(test_specs, test_modules):
     return result
 
 def die(msg, exit_val=1):
-    print msg
     logging.critical(msg)
     sys.exit(exit_val)
 
@@ -496,6 +495,33 @@ def _space_to(n, str):
         return " " * spaces
     return " "
 
+def test_params_parse(config):
+    test_params = config["test_params"]
+    if test_params is None:
+        logging.debug(
+            "No test params were provided with '--test-params' / '-t'")
+        return None
+    params_str = "class _TestParams:\n    " + test_params
+    try:
+        exec params_str
+    except:
+        logging.error(
+            "Error when parsing test params "
+            "(provided with '--test-params' / '-t'). "
+            "Make sure you used the correct syntax: "
+            "--test-params=\"[k=v;]*k=v\"")
+        return None
+    params = {}
+    logging.debug("Parsed test parameters:")
+    for k, v in vars(_TestParams).items():
+        if k[:2] != "__":
+            params[k] = v
+            logging.debug("\t*{}={}".format(k, v))
+    logging.debug(
+        "If something is missing, make sure you used the correct syntax: "
+        "--test-params=\"[k=v;]*k=v\"")
+    return params
+
 #
 # Main script
 #
@@ -507,6 +533,10 @@ ptf.config.update(new_config)
 logging_setup(config)
 xunit_setup(config)
 logging.info("++++++++ " + time.asctime() + " ++++++++")
+
+# import after logging is configured so that scapy error logs (from importing
+# packet.py) are silenced and our own warnings are logged properly.
+import ptf.testutils
 
 test_specs = args.test_specs
 if config["test_file"] != None:
@@ -621,7 +651,7 @@ except:
     logging.warn("Could not run platform host configuration")
     raise
 
-if not config["port_map"]:
+if config["port_map"] is None:
     die("Interface port map was not defined by the platform. Exiting.")
 
 logging.debug("Configuration: " + str(config))
@@ -630,11 +660,11 @@ logging.info("port map: " + str(config["port_map"]))
 ptf.ptfutils.default_timeout = config["default_timeout"]
 ptf.ptfutils.default_negative_timeout = config["default_negative_timeout"]
 ptf.testutils.MINSIZE = config['minsize']
+# Try parsing test params and log them
+ptf.testutils.TEST_PARAMS = test_params_parse(config)
 
 if os.getuid() != 0 and not config["allow_user"] and platform_name != "nn":
-    print "ERROR: Super-user privileges required. Please re-run with " \
-          "sudo or as root."
-    sys.exit(1)
+    die("Super-user privileges required. Please re-run with sudo or as root.")
 
 if config["random_seed"] is not None:
     logging.info("Random seed: %d" % config["random_seed"])

--- a/src/ptf/__init__.py
+++ b/src/ptf/__init__.py
@@ -34,7 +34,29 @@ def open_logfile(name):
         logger.removeHandler(handler)
         handler.close()
 
+    formatter = logging.Formatter(_format, _datefmt)
+
     # Add a new handler
     handler = logging.FileHandler(filename, mode='a')
-    handler.setFormatter(logging.Formatter(_format, _datefmt))
+    handler.setFormatter(formatter)
     logger.addHandler(handler)
+
+    # We log all ERROR and CRITICAL messages to stdout as well as to the
+    # logfile.
+    stream_handler = logging.StreamHandler()
+    stream_handler.setLevel(logging.ERROR)
+    stream_handler.setFormatter(formatter)
+    logger.addHandler(stream_handler)
+
+def disable_logging():
+    """
+    Temporarily disable all logging by setting the global log level to
+    CRITICAL, which is the highest log level in use.
+    """
+    logging.disable(logging.CRITICAL)
+
+def enable_logging():
+    """
+    Turn logging back on after a call to disable_logging().
+    """
+    logging.disable(logging.NOTSET)

--- a/src/ptf/packet.py
+++ b/src/ptf/packet.py
@@ -4,6 +4,7 @@
 """
 Wrap scapy to satisfy pylint
 """
+import ptf
 from ptf import config
 import sys
 import logging
@@ -50,10 +51,13 @@ if not config.get("disable_ipv6", False):
 VXLAN = None
 if not config.get("disable_vxlan", False):
     try:
+        ptf.disable_logging()
         scapy.main.load_contrib("vxlan")
         VXLAN = scapy.contrib.vxlan.VXLAN
+        ptf.enable_logging()
         logging.info("VXLAN support found in Scapy")
     except:
+        ptf.enable_logging()
         logging.warn("VXLAN support not found in Scapy")
         pass
 
@@ -62,41 +66,53 @@ ERSPAN_III = None
 PlatformSpecific = None
 if not config.get("disable_erspan", False):
     try:
+        ptf.disable_logging()
         scapy.main.load_contrib("erspan")
         ERSPAN = scapy.contrib.erspan.ERSPAN
         ERSPAN_III = scapy.contrib.erspan.ERSPAN_III
         PlatformSpecific = scapy.contrib.erspan.PlatformSpecific
+        ptf.enable_logging()
         logging.info("ERSPAN support found in Scapy")
     except:
+        ptf.enable_logging()
         logging.warn("ERSPAN support not found in Scapy")
         pass
 
 GENEVE = None
 if not config.get("disable_geneve", False):
     try:
+        ptf.disable_logging()
         scapy.main.load_contrib("geneve")
         GENEVE = scapy.contrib.geneve.GENEVE
+        ptf.enable_logging()
         logging.info("GENEVE support found in Scapy")
     except:
+        ptf.enable_logging()
         logging.warn("GENEVE support not found in Scapy")
         pass
 
 MPLS = None
 if not config.get("disable_mpls", False):
     try:
+        ptf.disable_logging()
         scapy.main.load_contrib("mpls")
         MPLS = scapy.contrib.mpls.MPLS
+        ptf.enable_logging()
         logging.info("MPLS support found in Scapy")
     except:
+        ptf.enable_logging()
         logging.warn("MPLS support not found in Scapy")
         pass
 
 NVGRE = None
 if not config.get("disable_nvgre", False):
     try:
+        ptf.disable_logging()
         scapy.main.load_contrib("nvgre")
         NVGRE = scapy.contrib.nvgre.NVGRE
+        ptf.enable_logging()
         logging.info("NVGRE support found in Scapy")
     except:
+        ptf.enable_logging()
         logging.warn("NVGRE support not found in Scapy")
         pass

--- a/src/ptf/platforms/dummy.py
+++ b/src/ptf/platforms/dummy.py
@@ -1,0 +1,14 @@
+"""
+A dummy platform that returns an empty port map. Cannot be used for any
+meaningful dataplane testing (unless ports are added dynamically as part of the
+test).
+"""
+
+def platform_config_update(config):
+    """
+    Update configuration for the local platform
+
+    @param config The configuration dictionary to use/update
+    """
+
+    config['port_map'] = {}

--- a/src/ptf/testutils.py
+++ b/src/ptf/testutils.py
@@ -22,6 +22,7 @@ TCP_PROTOCOL = 0x6
 UDP_PROTOCOL = 0x11
 
 MINSIZE = 0
+TEST_PARAMS = None
 
 _import_blacklist.add('FILTERS')
 FILTERS = []
@@ -2214,24 +2215,16 @@ def test_params_get(default={}):
     """
     Return all the values passed via test-params if present
 
-    @param default Default dictionary to use if no valid params found
+    @param default Default dictionary to use if no params were provided or if
+    the provided string could not be "exec'd".
 
     WARNING: TEST PARAMETERS MUST BE PYTHON IDENTIFIERS;
     AND CANNOT START WITH "__";
     eg egr_count, not egr-count.
     """
-    test_params = ptf.config["test_params"]
-    params_str = "class _TestParams:\n    " + test_params
-    try:
-        exec params_str
-    except:
+    if TEST_PARAMS is None:
         return default
-
-    params = {}
-    for k, v in vars(_TestParams).items():
-        if k[:2] != "__":
-            params[k] = v
-    return params
+    return TEST_PARAMS
 
 def test_param_get(key, default=None):
     """

--- a/utests/specs/test.py
+++ b/utests/specs/test.py
@@ -1,0 +1,26 @@
+import ptf
+from ptf.base_tests import BaseTest
+from ptf import testutils
+
+class TestParamsGet(BaseTest):
+    def setUp(self):
+        BaseTest.setUp(self)
+
+    def runTest(self):
+        params = testutils.test_params_get(default=None)
+        if params is None:
+            print ">>>None"
+        else:
+            for k, v in params.items():
+                print ">>>{}={}".format(k, v)
+
+class TestParamGet(BaseTest):
+    def setUp(self):
+        BaseTest.setUp(self)
+
+    def runTest(self):
+        v = testutils.test_param_get('k1', default=-1)
+        if v is None:
+            print ">>>None"
+        else:
+            print ">>>k1={}".format(v)

--- a/utests/tests/test.py
+++ b/utests/tests/test.py
@@ -1,0 +1,77 @@
+import nose2.tools
+import subprocess
+import unittest
+
+class BaseTestCase(unittest.TestCase):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    def setUp(self):
+        super().setUp()
+
+    def run_ptf(self, args=[], input=None):
+        # redirect stderr to stdout so we can get error messages
+        r = subprocess.run(
+            ['./ptf'] + args,
+            stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+            input=input,
+            universal_newlines=True)
+        return r.returncode, r.stdout
+
+    def tearDown(self):
+        super().tearDown()
+
+
+class TestParamsTestCase(BaseTestCase):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.testdir = 'utests/specs'
+
+    def parse_params(self, out):
+        params = {}
+        for line in out.splitlines():
+            if not line.startswith('>>>'):
+                continue
+            line = line[3:]
+            if line == "None":
+                return None
+            k, v = line.split('=')
+            params[k] = int(v)
+        return params
+
+    def do_test_params(self, testspec, test_params_str):
+        rc, out = self.run_ptf(
+            args=['--test-dir', self.testdir,
+                  '--test-params={}'.format(test_params_str),
+                  '--platform', 'dummy', testspec])
+        self.assertEqual(rc, 0)
+        return out
+
+    @nose2.tools.params(("k1=9;k2=18", {'k1':9, 'k2':18}),
+                        ("k1=9;k2=18;", {'k1':9, 'k2':18}))
+    def test_test_params_get(self, test_params_str, expected_params):
+        testspec = "test.TestParamsGet"
+        out = self.do_test_params(testspec, test_params_str)
+        params = self.parse_params(out)
+        self.assertEqual(params, expected_params)
+
+    @nose2.tools.params(("bad", None))
+    def test_test_params_get_error(self, test_params_str, expected_params):
+        testspec = "test.TestParamsGet"
+        out = self.do_test_params(testspec, test_params_str)
+        self.assertIn("Error when parsing test params", out)
+
+    @nose2.tools.params(("k1=9;k2=18", 9),
+                        ("k1=9;k2=18;", 9),
+                        ("k2=18", -1))
+    def test_test_param_get(self, test_params_str, expected_value):
+        testspec = "test.TestParamGet"
+        out = self.do_test_params(testspec, test_params_str)
+        params = self.parse_params(out)
+        self.assertEqual(params['k1'], expected_value)
+
+    @nose2.tools.params(("bad", None))
+    def test_test_param_get_error(self, test_params_str, expected_params):
+        testspec = "test.TestParamGet"
+        out = self.do_test_params(testspec, test_params_str)
+        self.assertIn("Error when parsing test params", out)


### PR DESCRIPTION
Log an error message when the string passed to --test-params cannot be
evaluate by Python's exec method.

Also includes some minor improvement to logging. In particular, some scapy
error logs are suppressed and we now log errors to stdout.

We test the new --test-params code with some Python (python3) unit
tests. Unfortunately ptf is not very unit test friendly at the moment so we
actually start a ptf process with subprocess and inspect stdout /
stderr. Ideally, the ptf script would be change in the future so that ptf can be
run as a function and methods can be independently tested.