### PR TITLE
Fix IP protocol number for encapsulated IPv4

### DIFF
--- a/src/ptf/testutils.py
+++ b/src/ptf/testutils.py
@@ -1392,7 +1392,7 @@ def simple_ipv4ip_packet(pktlen=300,
     else:
         pkt = pkt / scapy.IP()
         pkt = pkt/("D" * (pktlen - len(pkt)))
-        pkt['IP'].proto = 41
+        pkt['IP'].proto = 4
 
     return pkt
 


### PR DESCRIPTION
This is an encapsulated IPv4 packet, not IPv6: https://github.com/p4lang/ptf/commit/23bd407730f3fced8ebb1f141c4b503b8162148c#diff-e724841c5944b5f3968e59b558a34cd3R1393