### PR TITLE
[setup] include ptf_nn_agent script in the package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,10 @@ setup(
         'ptf', 'ptf.platforms',
     ],
     package_dir={'': 'src'},
-    scripts=['ptf'],
+    scripts=[
+        'ptf',
+        'ptf_nn/ptf_nn_agent.py'
+    ],
     zip_safe=False,
     license='Apache License',
     keywords='ptf',


### PR DESCRIPTION
We would like to have ptf_nn_agent script as part of ptf package.
Currently we install ptf as deb package, and end up using `wget`  to get the `ptf_nn_agent.py`.

Signed-off-by: Mykola Faryma <mykolaf@mellanox.com>