### PR TITLE
Fix crash in simple_eth_raw_packet_with_taglist()

### DIFF
--- a/src/ptf/testutils.py
+++ b/src/ptf/testutils.py
@@ -1739,9 +1739,11 @@ def simple_eth_raw_packet_with_taglist(pktlen=60,
         for i in range(1, len(dl_tpid_list)):
             pkt[Dot1Q:i].type=dl_tpid_list[i]
         pkt.type=dl_tpid_list[0]
+        pkt[Dot1Q:len(dl_tpid_list)].type = pktlen - len(pkt)
+    else:
+       pkt.type = pktlen - len(pkt)
 
     # Fill payload length
-    pkt[Dot1Q:len(dl_tpid_list)].type = pktlen - len(pkt)
     pkt = pkt/codecs.decode("".join(["%02x"%(x%256) for x in range(pktlen - len(pkt))]), "hex")
     return pkt
 


### PR DESCRIPTION
When call **_[simple_eth_raw_packet_with_taglist()](https://github.com/p4lang/ptf/blob/c916077de445d6f604048580ed8b7af8e2d0daa7/src/ptf/testutils.py#L1703)_** with with **_False_** as  **[_dl_taglist_enable_](https://github.com/p4lang/ptf/blob/c916077de445d6f604048580ed8b7af8e2d0daa7/src/ptf/testutils.py#L1706)** paramters, we can see next error:
`IndexError('Layer [Dot1Q] not found',)`