### PR TITLE
Fix uncatched RuntimeError throwed when socket error while receiving packet

### DIFF
--- a/ptf_nn/ptf_nn_agent.py
+++ b/ptf_nn/ptf_nn_agent.py
@@ -265,7 +265,7 @@ class IfaceMgr(threading.Thread):
                 while True:
                     msg = afpacket.recv(self.socket, 4096)
                     self.received(msg)
-            except socket.error as err:
+            except (socket.error, RuntimeError) as err:
                 logger.debug("IfaceMgr {}-{} ({}) Error reading from the socket.".format(
                              self.dev, self.port, self.iface_name))
                 self.socket.close()


### PR DESCRIPTION
afpacket.recv will throw RuntimeError when sniffed interface had link flipped. (when raw socket failed)
IfaceMgr doesn't catch the RuntimeError causing thread exit the main loop, thus can't receive packet anymore.