### PR TITLE
Document Python 3 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ dataplane and is independent of OpenFlow. We also added several
 
 The following software is required to run PTF:
 
- * Python 2.7
+ * Python 2.7 or 3.x
  * Scapy
  * pypcap (optional - VLAN tests will fail without this)
  * tcpdump (optional - Scapy will complain if it's missing)

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,8 @@ setup(
         'Intended Audience :: Developers',
         'License :: OSI Approved :: Apache License',
         'Natural Language :: English',
-        "Programming Language :: Python :: 2",
+        'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
     ]
 )


### PR DESCRIPTION
Comparability with Python 3 has already been introduced with https://github.com/p4lang/ptf/pull/106.

Resolves #132