### PR TITLE
Some cleanup to packet library and the testutils

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,12 +25,11 @@ jobs:
         sudo apt-get install python3-dev
         sudo apt-get install python3-pip
         sudo apt-get install ethtool
-        sudo apt-get remove python-scapy
-        git clone https://github.com/p4lang/scapy-vxlan.git && cd scapy-vxlan && sudo python setup.py install && cd ..
         bash CI/travis/install-nanomsg.sh
         sudo ldconfig
         bash CI/travis/install-nnpy.sh
-        sudo pip3 install nose2
+        sudo pip install scapy
+        sudo pip3 install nose2 scapy
 
     - name: Install
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,11 +25,14 @@ jobs:
         sudo apt-get install python3-dev
         sudo apt-get install python3-pip
         sudo apt-get install ethtool
+        sudo pip install setuptools
+        sudo pip install scapy
+        sudo pip3 install setuptools
+        sudo pip3 install nose2 scapy
+
         bash CI/travis/install-nanomsg.sh
         sudo ldconfig
         bash CI/travis/install-nnpy.sh
-        sudo pip install setuptools scapy
-        sudo pip3 install setuptools nose2 scapy
 
     - name: Install
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,8 +28,8 @@ jobs:
         bash CI/travis/install-nanomsg.sh
         sudo ldconfig
         bash CI/travis/install-nnpy.sh
-        sudo pip install scapy
-        sudo pip3 install nose2 scapy
+        sudo pip install setuptools scapy
+        sudo pip3 install setuptools nose2 scapy
 
     - name: Install
       run: |

--- a/README.md
+++ b/README.md
@@ -29,8 +29,7 @@ The following software is required to run PTF:
  * tcpdump (optional - Scapy will complain if it's missing)
 
 We recommend that you install our extension of Scapy, which you can obtain
-[here](https://github.com/p4lang/scapy-vxlan). It adds support for additional
-header types: `VXLAN`, `ERSPAN`, `GENEVE`, `MPLS` and `NVGRE`.
+[here](https://github.com/p4lang/scapy-vxlan). It adds support for `NVGRE` header type.
 
 Scapy version 2.4.4 is needed for `ROCEv2` header type.
 

--- a/README.md
+++ b/README.md
@@ -24,14 +24,9 @@ dataplane and is independent of OpenFlow. We also added several
 The following software is required to run PTF:
 
  * Python 2.7 or 3.x
- * Scapy
+ * Scapy 2.4.4
  * pypcap (optional - VLAN tests will fail without this)
  * tcpdump (optional - Scapy will complain if it's missing)
-
-We recommend that you install our extension of Scapy, which you can obtain
-[here](https://github.com/p4lang/scapy-vxlan). It adds support for `NVGRE` header type.
-
-Scapy version 2.4.4 is needed for `ROCEv2` header type.
 
 Root/sudo privilege is required on the host, in order to run `ptf`.
 

--- a/src/ptf/packet.py
+++ b/src/ptf/packet.py
@@ -15,6 +15,7 @@ try:
     import scapy.layers.l2
     import scapy.layers.inet
     import scapy.layers.dhcp
+    import scapy.layers.vxlan
     import scapy.packet
     import scapy.main
     if not config.get("disable_ipv6", False):
@@ -41,6 +42,7 @@ ICMP = scapy.layers.inet.ICMP
 DHCP = scapy.layers.dhcp.DHCP
 BOOTP = scapy.layers.dhcp.BOOTP
 PADDING = scapy.packet.Padding
+VXLAN = scapy.layers.vxlan.VXLAN
 
 BTH = None
 if not config.get("disable_rocev2", False):
@@ -61,19 +63,6 @@ if not config.get("disable_ipv6", False):
     ICMPv6Unknown = scapy.layers.inet6.ICMPv6Unknown
     ICMPv6EchoRequest = scapy.layers.inet6.ICMPv6EchoRequest
 
-VXLAN = None
-if not config.get("disable_vxlan", False):
-    try:
-        ptf.disable_logging()
-        scapy.main.load_contrib("vxlan")
-        VXLAN = scapy.contrib.vxlan.VXLAN
-        ptf.enable_logging()
-        logging.info("VXLAN support found in Scapy")
-    except:
-        ptf.enable_logging()
-        logging.warn("VXLAN support not found in Scapy")
-        pass
-
 ERSPAN = None
 ERSPAN_III = None
 PlatformSpecific = None
@@ -83,7 +72,7 @@ if not config.get("disable_erspan", False):
         scapy.main.load_contrib("erspan")
         ERSPAN = scapy.contrib.erspan.ERSPAN
         ERSPAN_III = scapy.contrib.erspan.ERSPAN_III
-        PlatformSpecific = scapy.contrib.erspan.PlatformSpecific
+        PlatformSpecific = scapy.contrib.erspan.ERSPAN_PlatformSpecific
         ptf.enable_logging()
         logging.info("ERSPAN support found in Scapy")
     except:

--- a/src/ptf/packet.py
+++ b/src/ptf/packet.py
@@ -62,6 +62,7 @@ if not config.get("disable_ipv6", False):
     IPv6ExtHdrRouting = scapy.layers.inet6.IPv6ExtHdrRouting
     ICMPv6Unknown = scapy.layers.inet6.ICMPv6Unknown
     ICMPv6EchoRequest = scapy.layers.inet6.ICMPv6EchoRequest
+    ICMPv6MLReport = scapy.layers.inet6.ICMPv6MLReport
 
 ERSPAN = None
 ERSPAN_III = None

--- a/src/ptf/testutils.py
+++ b/src/ptf/testutils.py
@@ -140,7 +140,7 @@ def simple_tcp_packet_ext_taglist(pktlen=100,
               tcp_hdr
 
         for i in range(1, len(dl_tpid_list)):
-            pkt[Dot1Q:i].type=dl_tpid_list[i]
+            pkt[scapy.Dot1Q:i].type=dl_tpid_list[i]
         pkt.type=dl_tpid_list[0]
 
     else:
@@ -502,7 +502,7 @@ def simple_geneve_packet(pktlen=300,
                 scapy.IP(src=ip_src, dst=ip_dst, tos=ip_tos, ttl=ip_ttl, id=ip_id, flags=ip_flags, ihl=ip_ihl, options=ip_options)/ \
                 udp_hdr
 
-    pkt = pkt / GENEVE(vni = geneve_vni, proto = geneve_proto )
+    pkt = pkt / scapy.GENEVE(vni = geneve_vni, proto = geneve_proto )
 
     if inner_frame:
         pkt = pkt / inner_frame
@@ -676,7 +676,7 @@ def simple_vxlan_packet(pktlen=300,
                 scapy.IP(src=ip_src, dst=ip_dst, tos=ip_tos, ttl=ip_ttl, id=ip_id, flags=ip_flags, ihl=ip_ihl, options=ip_options)/ \
                 udp_hdr
 
-    pkt = pkt / VXLAN(vni = vxlan_vni, reserved1 = vxlan_reserved1, reserved2 = vxlan_reserved2)
+    pkt = pkt / scapy.VXLAN(vni = vxlan_vni, reserved1 = vxlan_reserved1, reserved2 = vxlan_reserved2)
 
     if inner_frame:
         pkt = pkt / inner_frame
@@ -755,7 +755,7 @@ def simple_vxlanv6_packet(pktlen=300,
               scapy.IPv6(src=ipv6_src, dst=ipv6_dst, fl=ipv6_fl, tc=ipv6_tc, hlim=ipv6_hlim)/ \
             udp_hdr
 
-    pkt = pkt / VXLAN(vni = vxlan_vni, reserved1 = vxlan_reserved1, reserved2 = vxlan_reserved2)
+    pkt = pkt / scapy.VXLAN(vni = vxlan_vni, reserved1 = vxlan_reserved1, reserved2 = vxlan_reserved2)
 
     if inner_frame:
         pkt = pkt / inner_frame
@@ -1636,7 +1636,7 @@ def simple_ipv6_mld_packet(pktlen=300,
         pkt = scapy.Ether(dst=eth_dst, src=eth_src)/ \
               scapy.IPv6(src=ipv6_src, dst=ipv6_dst, fl=ipv6_fl, tc=ipv6_tc, hlim=ipv6_hlim, nh=next_header)
 
-    pkt = pkt / ICMPv6MLReport(type=mld_type, mladdr=mld_mladdr, mrd=mld_mrd)
+    pkt = pkt / scapy.ICMPv6MLReport(type=mld_type, mladdr=mld_mladdr, mrd=mld_mrd)
 
     if inner_frame:
         pkt = pkt / inner_frame
@@ -1737,9 +1737,9 @@ def simple_eth_raw_packet_with_taglist(pktlen=60,
             pkt = pkt/scapy.Dot1Q(prio=dl_vlan_pcp_list[i], id=dl_vlan_cfi_list[i], vlan=dl_vlanid_list[i])
 
         for i in range(1, len(dl_tpid_list)):
-            pkt[Dot1Q:i].type=dl_tpid_list[i]
+            pkt[scapy.Dot1Q:i].type=dl_tpid_list[i]
         pkt.type=dl_tpid_list[0]
-        pkt[Dot1Q:len(dl_tpid_list)].type = pktlen - len(pkt)
+        pkt[scapy.Dot1Q:len(dl_tpid_list)].type = pktlen - len(pkt)
     else:
        pkt.type = pktlen - len(pkt)
 
@@ -1894,16 +1894,16 @@ def simple_mpls_packet(pktlen=300,
         pktlen = MINSIZE
 
     pkt = scapy.Ether(dst=eth_dst, src=eth_src)
-    pkt[Ether].setfieldval('type', mpls_type)
+    pkt[scapy.Ether].setfieldval('type', mpls_type)
 
     if (dl_vlan_enable):
         pkt / scapy.Dot1Q(prio=vlan_pcp, id=dl_vlan_cfi, vlan=vlan_vid)
-        pkt[Dot1Q].setfieldval('type', mpls_type)
+        pkt[scapy.Dot1Q].setfieldval('type', mpls_type)
 
     mpls_tags = list(mpls_tags)
     while len(mpls_tags):
         tag = mpls_tags.pop(0)
-        mpls = MPLS()
+        mpls = scapy.MPLS()
         if 'label' in tag:
             mpls.label = tag['label']
         if 'tc' in tag:
@@ -2050,7 +2050,7 @@ def simple_igmp_packet(pktlen=300,
             pkt = scapy.Ether(dst=eth_dst, src=eth_src)/ \
                 scapy.IP(src=ip_src, dst=ip_dst, tos=ip_tos, ttl=ip_ttl, id=ip_id, ihl=ip_ihl, options=ip_options)
 
-    pkt = pkt / IGMP(type=igmp_type, gaddr=igmp_gaddr, mrtime=igmp_mrtime)
+    pkt = pkt / scapy.IGMP(type=igmp_type, gaddr=igmp_gaddr, mrtime=igmp_mrtime)
 
     if inner_frame:
         pkt = pkt / inner_frame
@@ -2486,7 +2486,7 @@ def ptf_ports(num=None):
     return ports[:num]
 
 def port_to_tuple(port):
-    if type(port) is int or (sys.version_info[0] == 2 and type(port) is long):
+    if type(port) is int or (sys.version_info[0] == 2 and type(port) is int):
         return 0, port
     if type(port) is tuple:
         return port


### PR DESCRIPTION
Scapy 2.4.4 supports `VXLAN`, `ERSPAN`, `GENEVE`, `MPLS`
We can include them from the Scapy directly without installing the `p4lang/scapy-vxlan`
Also some cleanup to the test utility
 - Missing `scapy.` for some types (e.g., Dot1Q should be scapy.Dot1Q)
 - Use `int` instead of `long` since they already unified, see [EP237](https://www.python.org/dev/peps/pep-0237/)