### PR TITLE
Provide ptf support for passing port information with --interface option

### DIFF
--- a/ptf
+++ b/ptf
@@ -133,6 +133,7 @@ be subtracted from the result by prefixing them with the '^' character.  """
             # Parse --interface
             def check_interface(value):
                 try:
+                    value, port_info = value.split(';', 1)
                     dev_and_port, interface = value.split('@', 1)
                     dev_and_port = dev_and_port.split("-")
                     if len(dev_and_port) == 1:
@@ -143,7 +144,7 @@ be subtracted from the result by prefixing them with the '^' character.  """
                         raise ValueError("")
                 except ValueError:
                     parser.error("incorrect interface syntax (got %s, expected 'port@interface' or 'device-port@interface')" % repr(value))
-                return (dev, port, interface)
+                return (dev, port, interface, port_info)
 
             assert(type(values) is str)
             getattr(namespace, self.dest).append(check_interface(values))

--- a/ptf
+++ b/ptf
@@ -133,14 +133,15 @@ be subtracted from the result by prefixing them with the '^' character.  """
         def __call__(self, parser, namespace, values, option_string=None):
             # Parse --interface
             def check_interface(value):
+                port_cfg = {}
                 sp = ';'
                 try:
                     if sp in value:
                         value, p_info = value.split(sp, 1)
                         params = p_info.split(sp)
-                        port = params.pop(0)
-                        port_cfg = dict(val.split("=") for val in params)
-                        getattr(namespace, "port_info")[port] = port_cfg
+                        for elem in params:
+                            key, val = elem.split("=")
+                            port_cfg[key.lower()] = val
                     dev_and_port, interface = value.split('@', 1)
                     dev_and_port = dev_and_port.split("-")
                     if len(dev_and_port) == 1:
@@ -149,6 +150,8 @@ be subtracted from the result by prefixing them with the '^' character.  """
                         dev, port = int(dev_and_port[0]), int(dev_and_port[1])
                     else:
                         raise ValueError("")
+                    if port_cfg:
+                        getattr(namespace, "port_info")[port] = port_cfg
                 except ValueError:
                     parser.error("incorrect interface syntax (got %s, expected 'port@interface' or 'device-port@interface' \
                                   or providing port configuration using 'device-port@interface;arg=val;arg2=val...' )" % repr(value))

--- a/ptf
+++ b/ptf
@@ -133,7 +133,10 @@ be subtracted from the result by prefixing them with the '^' character.  """
             # Parse --interface
             def check_interface(value):
                 try:
-                    value, port_info = value.split(';', 1)
+                    port_info = ""
+                    sp = ';'
+                    if sp in value:
+                        value, port_info = value.split(sp, 1)
                     dev_and_port, interface = value.split('@', 1)
                     dev_and_port = dev_and_port.split("-")
                     if len(dev_and_port) == 1:

--- a/ptf
+++ b/ptf
@@ -66,6 +66,7 @@ config_default = {
     "platform_args"      : None,
     "platform_dir"       : None,
     "interfaces"         : [],
+    "port_info"          : {},
     "device_sockets"     : [],  # when using nanomsg
 
     # Logging options
@@ -133,10 +134,14 @@ be subtracted from the result by prefixing them with the '^' character.  """
             # Parse --interface
             def check_interface(value):
                 try:
-                    port_info = ""
                     sp = ';'
                     if sp in value:
-                        value, port_info = value.split(sp, 1)
+                        value, p_info = value.split(sp, 1)
+                        params = p_info.split(sp)
+                        port = params.pop(0)
+                        params.pop()
+                        port_cfg = dict(val.split("=") for val in params)
+                        getattr(namespace, "port_info")[port] = port_cfg
                     dev_and_port, interface = value.split('@', 1)
                     dev_and_port = dev_and_port.split("-")
                     if len(dev_and_port) == 1:
@@ -148,7 +153,7 @@ be subtracted from the result by prefixing them with the '^' character.  """
                 except ValueError:
                     parser.error("incorrect interface syntax (got %s, expected 'port@interface' or 'device-port@interface' \
                                   or providing port configuration using 'device-port@interface;arg=val;arg2=val...' )" % repr(value))
-                return (dev, port, interface, port_info)
+                return (dev, port, interface)
 
             assert(type(values) is str)
             getattr(namespace, self.dest).append(check_interface(values))
@@ -560,6 +565,8 @@ import ptf.testutils
 # We do this before importing the test modules in case test parameters are being
 # accessed at test import time.
 ptf.testutils.TEST_PARAMS = test_params_parse(config)
+# Initiallize port information
+ptf.testutils.PORT_INFO = config["port_info"]
 
 test_specs = args.test_specs
 if config["test_file"] != None:

--- a/ptf
+++ b/ptf
@@ -139,7 +139,6 @@ be subtracted from the result by prefixing them with the '^' character.  """
                         value, p_info = value.split(sp, 1)
                         params = p_info.split(sp)
                         port = params.pop(0)
-                        params.pop()
                         port_cfg = dict(val.split("=") for val in params)
                         getattr(namespace, "port_info")[port] = port_cfg
                     dev_and_port, interface = value.split('@', 1)

--- a/ptf
+++ b/ptf
@@ -133,8 +133,8 @@ be subtracted from the result by prefixing them with the '^' character.  """
         def __call__(self, parser, namespace, values, option_string=None):
             # Parse --interface
             def check_interface(value):
+                sp = ';'
                 try:
-                    sp = ';'
                     if sp in value:
                         value, p_info = value.split(sp, 1)
                         params = p_info.split(sp)

--- a/ptf
+++ b/ptf
@@ -146,7 +146,8 @@ be subtracted from the result by prefixing them with the '^' character.  """
                     else:
                         raise ValueError("")
                 except ValueError:
-                    parser.error("incorrect interface syntax (got %s, expected 'port@interface' or 'device-port@interface')" % repr(value))
+                    parser.error("incorrect interface syntax (got %s, expected 'port@interface' or 'device-port@interface' \
+                                  or providing port configuration using 'device-port@interface;arg=val;arg2=val...' )" % repr(value))
                 return (dev, port, interface, port_info)
 
             assert(type(values) is str)

--- a/src/ptf/platforms/eth.py
+++ b/src/ptf/platforms/eth.py
@@ -13,7 +13,7 @@ def platform_config_update(config):
 
     port_map = {}
 
-    for (device, port, interface) in config["interfaces"]:
+    for (device, port, interface, port_info) in config["interfaces"]:
         port_map[(device, port)] = interface
 
     # Default to a veth configuration compatible with the reference switch

--- a/src/ptf/platforms/eth.py
+++ b/src/ptf/platforms/eth.py
@@ -13,7 +13,7 @@ def platform_config_update(config):
 
     port_map = {}
 
-    for (device, port, interface, port_info) in config["interfaces"]:
+    for (device, port, interface) in config["interfaces"]:
         port_map[(device, port)] = interface
 
     # Default to a veth configuration compatible with the reference switch

--- a/src/ptf/testutils.py
+++ b/src/ptf/testutils.py
@@ -25,6 +25,7 @@ UDP_PROTOCOL = 0x11
 
 MINSIZE = 0
 TEST_PARAMS = None
+PORT_INFO = None
 
 _import_blacklist.add('FILTERS')
 FILTERS = []
@@ -2391,6 +2392,34 @@ def test_param_get(key, default=None):
 
     try:
         return params[key]
+    except:
+        return default
+
+def test_port_params_get(default={}):
+    """
+    Return all the port info values passed via --interface if present
+
+    @param default Default dictionary to use if no params were provided or if
+    the provided string could not be "exec'd".
+
+    """
+    if PORT_INFO is None:
+        return default
+    return PORT_INFO
+
+def port_param_get(port, key, default=None):
+    """
+    Return port info values passed via --interface if present
+
+    @param port The lookup key
+    @param key The lookup key
+    @param default Default value to use if not found
+
+    """
+    params = test_port_params_get()
+
+    try:
+        return params[port][key]
     except:
         return default
 

--- a/src/ptf/testutils.py
+++ b/src/ptf/testutils.py
@@ -2419,7 +2419,7 @@ def port_param_get(port, key, default=None):
     params = test_port_params_get()
 
     try:
-        return params[port][key]
+        return params[int(port)][key.lower()]
     except:
         return default
 

--- a/src/ptf/testutils.py
+++ b/src/ptf/testutils.py
@@ -2395,7 +2395,7 @@ def test_param_get(key, default=None):
     except:
         return default
 
-def test_port_params_get(default={}):
+def port_params_get(default={}):
     """
     Return all the port info values passed via --interface if present
 
@@ -2416,7 +2416,7 @@ def port_param_get(port, key, default=None):
     @param default Default value to use if not found
 
     """
-    params = test_port_params_get()
+    params = port_params_get()
 
     try:
         return params[int(port)][key.lower()]


### PR DESCRIPTION
Еhe possibility of passing port parameters for each specific interface provided: 

`--interfaces=0-1@veth1;speed=100g-r2;fec=rs;mtu=9192;other_param=some_value `

 
**Example:** 
```
{ 
            "device_port":64, 
            "if":"ens1f0", 
            "speed":"25G", 
            "conn_id":65, 
            "chnl_id":0 
} 
```

**Command:** 
`--interfaces=0-64@ens1f0;64;chnl_id=0;device_port=64;speed=25G;conn_id=65;if=ens1f0 `

To access the port parameters inside a test the `port_param_get()` API provided: 
`ptf.testutils.port_param_get(port, 'speed') `