### PR TITLE
fix(testutils.py): fix syntax error

### DIFF
--- a/src/ptf/testutils.py
+++ b/src/ptf/testutils.py
@@ -2663,7 +2663,7 @@ def verify_packets_any(test, pkt, ports=[], device_number=0, timeout=None, n_tim
     if not received:
         def format_failure(port, failure):
             return "On port %d:\n%s" % (port, failure.format())
-        failure_report = "\n".join([format_failure(f) for f in failures])
+        failure_report = "\n".join([format_failure(*f) for f in failures])
         test.fail("Did not receive expected packet on any of ports %r for device %d.\n%s"
                     % (ports, device_number, failure_report))
 


### PR DESCRIPTION
This PR fix the following error:

```
TypeError: format_failure() takes exactly 2 arguments (1 given)
```