### PR TITLE
Change prune_tests to only fail if a non-negated group is not matched

### DIFF
--- a/ptf
+++ b/ptf
@@ -488,7 +488,7 @@ def prune_tests(test_specs, test_modules):
                                 del result[modname]
                     matched = True
 
-        if not matched:
+        if not matched and not negated:
             die("test-spec element %s did not match any tests" % e)
 
     return result


### PR DESCRIPTION
Hi all, I'll provide some context to this PR below:

I am using the PTF framework as part of designing a new suite of tests to assess the performance of a P4 implementation on a leaf-spine fabric.

The existing test suite utilized profiles, which thus specified which test groups to perform. For example, if the `int` profile was specified, PTF tests for groups "all ^spgw ^bng ^dth ^p4rt ^int-dod" would be performed. 

For this new suite of tests, we are not using *all* of these groups anymore, but we are still using the profile approach (i.e. `int`) for readability, continuity, and practicality. The profile specification approach goes through the same Makefile regardless of test suite, which means that the PTF call for both the new and previous suite will still specify the groups "all ^spgw ^bng ^dth ^p4rt ^int-dod" when the profile `int` is specified.

Because the previous suite contained each group in its test files, including the negated ones, there were no issues encountered. However, since this new suite does not contain all groups specified, the error `"test-spec element spgw did not match any tests"` was encountered. 

Although this group was negated in the `ptf` call (`^spgw`), the function `prune_tests` (which triggers the error) still checks for the group to be matched in the test files before *not* testing it. If my understanding is correct, I believe it may be an oversight to trigger an error if a negated group is not found.