### PR TITLE
Adding stdout flush before exit(1)

### DIFF
--- a/ptf
+++ b/ptf
@@ -799,6 +799,14 @@ if __name__ == "__main__":
         print()
         print("******************************************")
         # exit(1) hangs sometimes
+        sys.stdout.flush()
         os._exit(1)
     if ptf.testutils.skipped_test_count > 0 and config["fail_skipped"]:
+        print()
+        print("******************************************")
+        print("ATTENTION: %d TESTS WERE SKIPPED!!!",
+                ptf.testutils.skipped_test_count)
+        print("******************************************")
+        print()
+        sys.stdout.flush()
         os._exit(1)


### PR DESCRIPTION
Sometimes we are seeing error logs missing and just "script exist (1)" text. This change is made in order to force buffer flush.