### PR TITLE
Add `ptf` file to Black

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,12 @@
 .PHONY: format-check
 format-check:
 	@echo "Checking format..."
-	python -m black --check src/
+	python -m black --check src/ ptf
 
 .PHONY: format
 format:
 	@echo "Formatting..."
-	python -m black src/
+	python -m black src/ ptf
 
 .PHONY: set-dev
 set-dev:

--- a/ptf
+++ b/ptf
@@ -11,7 +11,7 @@ oftest.config dictionary.
 
 import sys
 import argparse
-from subprocess import Popen,PIPE
+from subprocess import Popen, PIPE
 import logging
 import unittest
 import time
@@ -25,8 +25,8 @@ from collections import OrderedDict
 
 root_dir = os.path.dirname(os.path.realpath(__file__))
 
-pydir = os.path.join(root_dir, 'src')
-if os.path.exists(os.path.join(pydir, 'ptf')):
+pydir = os.path.join(root_dir, "src")
+if os.path.exists(os.path.join(pydir, "ptf")):
     # Running from source tree
     sys.path.insert(0, pydir)
 
@@ -37,73 +37,68 @@ import ptf.ptfutils
 ##@var DEBUG_LEVELS
 # Map from strings to debugging levels
 DEBUG_LEVELS = {
-    'debug'              : logging.DEBUG,
-    'verbose'            : logging.DEBUG,
-    'info'               : logging.INFO,
-    'warning'            : logging.WARNING,
-    'warn'               : logging.WARNING,
-    'error'              : logging.ERROR,
-    'critical'           : logging.CRITICAL
+    "debug": logging.DEBUG,
+    "verbose": logging.DEBUG,
+    "info": logging.INFO,
+    "warning": logging.WARNING,
+    "warn": logging.WARNING,
+    "error": logging.ERROR,
+    "critical": logging.CRITICAL,
 }
 
 ##@var config_default
 # The default configuration dictionary for PTF
 config_default = {
     # Miscellaneous options
-    "list"               : False,
-    "list_test_names"    : False,
-    "allow_user"         : False,
-
+    "list": False,
+    "list_test_names": False,
+    "allow_user": False,
     # Test selection options
-    "test_spec"          : "",
-    "test_file"          : None,
-    "test_dir"           : None,
-    "test_order"         : "default",
-    "test_order_seed"    : 0xaba,
-
+    "test_spec": "",
+    "test_file": None,
+    "test_dir": None,
+    "test_order": "default",
+    "test_order_seed": 0xABA,
     # Switch connection options
-    "platform"           : "eth",
-    "platform_args"      : None,
-    "platform_dir"       : None,
-    "interfaces"         : [],
-    "port_info"          : {},
-    "device_sockets"     : [],  # when using nanomsg
-
+    "platform": "eth",
+    "platform_args": None,
+    "platform_dir": None,
+    "interfaces": [],
+    "port_info": {},
+    "device_sockets": [],  # when using nanomsg
     # Logging options
-    "log_file"           : "ptf.log",
-    "log_dir"            : None,
-    "debug"              : "verbose",
-    "profile"            : False,
-    "profile_file"       : "profile.out",
-    "xunit"              : False,
-    "xunit_dir"          : "xunit",
-
+    "log_file": "ptf.log",
+    "log_dir": None,
+    "debug": "verbose",
+    "profile": False,
+    "profile_file": "profile.out",
+    "xunit": False,
+    "xunit_dir": "xunit",
     # Test behavior options
-    "relax"              : False,
-    "test_params"        : None,
-    "failfast"           : False,
-    "fail_skipped"       : False,
-    "default_timeout"    : 2.0,
-    "default_negative_timeout" : 0.1,
-    "minsize"            : 0,
-    "random_seed"        : None,
-    "disable_ipv6"       : False,
-    "disable_vxlan"      : False,
-    "disable_erspan"     : False,
-    "disable_geneve"     : False,
-    "disable_mpls"       : False,
-    "disable_nvgre"      : False,
-    "disable_igmp"       : False,
-    "disable_rocev2"     : False,
-    "qlen"               : 100,
-    "test_case_timeout"  : None,
-
+    "relax": False,
+    "test_params": None,
+    "failfast": False,
+    "fail_skipped": False,
+    "default_timeout": 2.0,
+    "default_negative_timeout": 0.1,
+    "minsize": 0,
+    "random_seed": None,
+    "disable_ipv6": False,
+    "disable_vxlan": False,
+    "disable_erspan": False,
+    "disable_geneve": False,
+    "disable_mpls": False,
+    "disable_nvgre": False,
+    "disable_igmp": False,
+    "disable_rocev2": False,
+    "qlen": 100,
+    "test_case_timeout": None,
     # Socket options
-    "socket_recv_size"   : 4096,
-
+    "socket_recv_size": 4096,
     # Other configuration
-    "port_map"           : None,
+    "port_map": None,
 }
+
 
 def config_setup():
     """
@@ -134,7 +129,7 @@ be subtracted from the result by prefixing them with the '^' character.  """
             # Parse --interface
             def check_interface(value):
                 port_cfg = {}
-                sp = ';'
+                sp = ";"
                 try:
                     if sp in value:
                         value, p_info = value.split(sp, 1)
@@ -142,7 +137,7 @@ be subtracted from the result by prefixing them with the '^' character.  """
                         for elem in params:
                             key, val = elem.split("=")
                             port_cfg[key.lower()] = val
-                    dev_and_port, interface = value.split('@', 1)
+                    dev_and_port, interface = value.split("@", 1)
                     dev_and_port = dev_and_port.split("-")
                     if len(dev_and_port) == 1:
                         dev, port = 0, int(dev_and_port[0])
@@ -153,11 +148,14 @@ be subtracted from the result by prefixing them with the '^' character.  """
                     if port_cfg:
                         getattr(namespace, "port_info")[port] = port_cfg
                 except ValueError:
-                    parser.error("incorrect interface syntax (got %s, expected 'port@interface' or 'device-port@interface' \
-                                  or providing port configuration using 'device-port@interface;arg=val;arg2=val...' )" % repr(value))
+                    parser.error(
+                        "incorrect interface syntax (got %s, expected 'port@interface' or 'device-port@interface' \
+                                  or providing port configuration using 'device-port@interface;arg=val;arg2=val...' )"
+                        % repr(value)
+                    )
                 return (dev, port, interface)
 
-            assert(type(values) is str)
+            assert type(values) is str
             getattr(namespace, self.dest).append(check_interface(values))
 
     class ActionDeviceSocket(argparse.Action):
@@ -188,129 +186,215 @@ be subtracted from the result by prefixing them with the '^' character.  """
                     return port_set
 
                 try:
-                    dev_and_port, addr = value.split('@', 1)
-                    if dev_and_port[0] == '{':
+                    dev_and_port, addr = value.split("@", 1)
+                    if dev_and_port[0] == "{":
                         dev, ports = (0, parse_ports(dev_and_port))
                     else:
                         dev_and_port = dev_and_port.split("-", 1)
                         if len(dev_and_port) != 2:
                             raise ValueError("")
-                        dev, ports = (int(dev_and_port[0]),
-                                      parse_ports(dev_and_port[1]))
+                        dev, ports = (
+                            int(dev_and_port[0]),
+                            parse_ports(dev_and_port[1]),
+                        )
                 except ValueError:
-                    parser.error("incorrect device-socket syntax (got %s, expected something of the form 0-{1,2,5-8}@<socket addr>)" % repr(value))
+                    parser.error(
+                        "incorrect device-socket syntax (got %s, expected something of the form 0-{1,2,5-8}@<socket addr>)"
+                        % repr(value)
+                    )
                 return (dev, ports, addr)
 
-            assert(type(values) is str)
+            assert type(values) is str
             getattr(namespace, self.dest).append(check_device_socket(values))
 
     class ActionTestDir(argparse.Action):
         def __call__(self, parser, namespace, values, option_string=None):
-            assert(type(values) is str)
+            assert type(values) is str
             if not os.path.isdir(values):
-                parser.error("invalid value for --test-dir: directory %s does not exist" % values)
+                parser.error(
+                    "invalid value for --test-dir: directory %s does not exist" % values
+                )
             setattr(namespace, self.dest, values)
 
-    parser = argparse.ArgumentParser(usage=usage,
-                                     description=description)
+    parser = argparse.ArgumentParser(usage=usage, description=description)
 
     # Set up default values
     parser.set_defaults(**config_default)
 
-    parser.add_argument('--version', action='version', version="ptf 0.1")
+    parser.add_argument("--version", action="version", version="ptf 0.1")
 
-    parser.add_argument("test_specs", nargs="*",
-                        help="Tests / Groups to run")
+    parser.add_argument("test_specs", nargs="*", help="Tests / Groups to run")
 
-    parser.add_argument("--list", action="store_true",
-                        help="List all tests and exit")
-    parser.add_argument("--list-test-names", action='store_true',
-                        help="List test names matching the test spec and exit")
-    parser.add_argument("--allow-user", action="store_true",
-                        help="Proceed even if ptf is not run as root")
+    parser.add_argument("--list", action="store_true", help="List all tests and exit")
+    parser.add_argument(
+        "--list-test-names",
+        action="store_true",
+        help="List test names matching the test spec and exit",
+    )
+    parser.add_argument(
+        "--allow-user",
+        action="store_true",
+        help="Proceed even if ptf is not run as root",
+    )
 
     parser.add_argument("--pypath", dest="pypath", action="append")
 
     group = parser.add_argument_group("Test selection options")
     group.add_argument("-f", "--test-file", help="File of tests to run, one per line")
-    group.add_argument("--test-dir", type=str, action=ActionTestDir,
-                       required=True, help="Directory containing tests")
+    group.add_argument(
+        "--test-dir",
+        type=str,
+        action=ActionTestDir,
+        required=True,
+        help="Directory containing tests",
+    )
     test_order_help = """Choose the order in which the tests will be run:
     default (tests are run in the order in which they appear on command line),
     lexico (use default string ordering on test names),
     rand (random order, use --test-order-seed to specify a seed)
     """
-    group.add_argument("--test-order",
-                       choices=["default", "lexico", "rand"],
-                       help=test_order_help)
-    group.add_argument("--test-order-seed", type=int,
-                       help="Specify seed to randomize test order")
+    group.add_argument(
+        "--test-order", choices=["default", "lexico", "rand"], help=test_order_help
+    )
+    group.add_argument(
+        "--test-order-seed", type=int, help="Specify seed to randomize test order"
+    )
 
     group = parser.add_argument_group("Switch connection options")
     group.add_argument("-P", "--platform", help="Platform module name")
-    group.add_argument("-a", "--platform-args", help="Custom arguments for the platform")
-    group.add_argument("--platform-dir", type=str, help="Directory containing platform modules")
-    group.add_argument("--interface", "-i", type=str, dest="interfaces", metavar="INTERFACE", action=ActionInterface,
-                       help="Specify a port number and the dataplane interface to use. May be given multiple times. Example: 1@eth1 or 0-1@eth2 (use eth2 as port 1 of device 0)")
-    group.add_argument("--device-socket", type=str, dest="device_sockets", metavar="DEVICE-SOCKET", action=ActionDeviceSocket,
-                       help="Specify the nanomsg socket to use to send / receive packets for a given device, as well as the ports to enable on the device. May be given multiple times. Example: 0-{1,2,5-8}@<socket addr>")
+    group.add_argument(
+        "-a", "--platform-args", help="Custom arguments for the platform"
+    )
+    group.add_argument(
+        "--platform-dir", type=str, help="Directory containing platform modules"
+    )
+    group.add_argument(
+        "--interface",
+        "-i",
+        type=str,
+        dest="interfaces",
+        metavar="INTERFACE",
+        action=ActionInterface,
+        help="Specify a port number and the dataplane interface to use. May be given multiple times. Example: 1@eth1 or 0-1@eth2 (use eth2 as port 1 of device 0)",
+    )
+    group.add_argument(
+        "--device-socket",
+        type=str,
+        dest="device_sockets",
+        metavar="DEVICE-SOCKET",
+        action=ActionDeviceSocket,
+        help="Specify the nanomsg socket to use to send / receive packets for a given device, as well as the ports to enable on the device. May be given multiple times. Example: 0-{1,2,5-8}@<socket addr>",
+    )
 
     group = parser.add_argument_group("Logging options")
     group.add_argument("--log-file", help="Name of log file")
     group.add_argument("--log-dir", help="Name of log directory")
     dbg_lvl_names = sorted(list(DEBUG_LEVELS.keys()), key=lambda x: DEBUG_LEVELS[x])
-    group.add_argument("--debug", choices=dbg_lvl_names,
-                       help="Debug lvl: debug, info, warning, error, critical")
-    group.add_argument("--verbose", action="store_const", dest="debug",
-                       const="verbose", help="Shortcut for --debug=verbose")
-    group.add_argument("-q", "--quiet", action="store_const", dest="debug",
-                       const="warning", help="Shortcut for --debug=warning")
+    group.add_argument(
+        "--debug",
+        choices=dbg_lvl_names,
+        help="Debug lvl: debug, info, warning, error, critical",
+    )
+    group.add_argument(
+        "--verbose",
+        action="store_const",
+        dest="debug",
+        const="verbose",
+        help="Shortcut for --debug=verbose",
+    )
+    group.add_argument(
+        "-q",
+        "--quiet",
+        action="store_const",
+        dest="debug",
+        const="warning",
+        help="Shortcut for --debug=warning",
+    )
     group.add_argument("--profile", action="store_true", help="Enable Python profiling")
     group.add_argument("--profile-file", help="Output file for Python profiler")
-    group.add_argument("--xunit", action="store_true", help="Enable xUnit-formatted results")
-    group.add_argument("--xunit-dir", help="Output directory for xUnit-formatted results")
+    group.add_argument(
+        "--xunit", action="store_true", help="Enable xUnit-formatted results"
+    )
+    group.add_argument(
+        "--xunit-dir", help="Output directory for xUnit-formatted results"
+    )
 
     group = parser.add_argument_group("Test behavior options")
-    group.add_argument("--relax", action="store_true",
-                      help="Relax packet match checks allowing other packets")
-    group.add_argument("--failfast", action="store_true",
-                      help="Stop running tests as soon as one fails")
+    group.add_argument(
+        "--relax",
+        action="store_true",
+        help="Relax packet match checks allowing other packets",
+    )
+    group.add_argument(
+        "--failfast",
+        action="store_true",
+        help="Stop running tests as soon as one fails",
+    )
     test_params_help = """Set test parameters: [key=val]*;key=val
     """
     group.add_argument("-t", "--test-params", help=test_params_help)
-    group.add_argument("--fail-skipped", action="store_true",
-                       help="Return failure if any test was skipped")
-    group.add_argument("--default-timeout", type=float,
-                       help="Timeout in seconds for most operations")
-    group.add_argument("--default-negative-timeout", type=float,
-                       help="Timeout in seconds for negative checks")
-    group.add_argument("--minsize", type=int,
-                       help="Minimum allowable packet size on the dataplane.")
-    group.add_argument("--random-seed", type=int,
-                       help="Random number generator seed")
-    group.add_argument("--disable-ipv6", action="store_true",
-                       help="Disable IPv6 tests")
-    group.add_argument("--qlen", type=int,
-                       help="Default queue length ")
-    group.add_argument("--test-case-timeout", type=int,
-                       help="Timeout for each test case, 0 means no timeout")
+    group.add_argument(
+        "--fail-skipped",
+        action="store_true",
+        help="Return failure if any test was skipped",
+    )
+    group.add_argument(
+        "--default-timeout", type=float, help="Timeout in seconds for most operations"
+    )
+    group.add_argument(
+        "--default-negative-timeout",
+        type=float,
+        help="Timeout in seconds for negative checks",
+    )
+    group.add_argument(
+        "--minsize", type=int, help="Minimum allowable packet size on the dataplane."
+    )
+    group.add_argument("--random-seed", type=int, help="Random number generator seed")
+    group.add_argument("--disable-ipv6", action="store_true", help="Disable IPv6 tests")
+    group.add_argument("--qlen", type=int, help="Default queue length ")
+    group.add_argument(
+        "--test-case-timeout",
+        type=int,
+        help="Timeout for each test case, 0 means no timeout",
+    )
 
-    group.add_argument("--disable-vxlan", action="store_true",
-                       help="Disable VXLAN (do not import from scapy even if supported)")
-    group.add_argument("--disable-geneve", action="store_true",
-                       help="Disable GENEVE (do not import from scapy even if supported)")
-    group.add_argument("--disable-erspan", action="store_true",
-                       help="Disable ERSPAN (do not import from scapy even if supported)")
-    group.add_argument("--disable-mpls", action="store_true",
-                       help="Disable MPLS (do not import from scapy even if supported)")
-    group.add_argument("--disable-nvgre", action="store_true",
-                       help="Disable NVGRE (do not import from scapy even if supported)")
-    group.add_argument("--disable-igmp", action="store_true",
-                       help="Disable IGMP (do not import from scapy even if supported)")
-                       
+    group.add_argument(
+        "--disable-vxlan",
+        action="store_true",
+        help="Disable VXLAN (do not import from scapy even if supported)",
+    )
+    group.add_argument(
+        "--disable-geneve",
+        action="store_true",
+        help="Disable GENEVE (do not import from scapy even if supported)",
+    )
+    group.add_argument(
+        "--disable-erspan",
+        action="store_true",
+        help="Disable ERSPAN (do not import from scapy even if supported)",
+    )
+    group.add_argument(
+        "--disable-mpls",
+        action="store_true",
+        help="Disable MPLS (do not import from scapy even if supported)",
+    )
+    group.add_argument(
+        "--disable-nvgre",
+        action="store_true",
+        help="Disable NVGRE (do not import from scapy even if supported)",
+    )
+    group.add_argument(
+        "--disable-igmp",
+        action="store_true",
+        help="Disable IGMP (do not import from scapy even if supported)",
+    )
+
     group = parser.add_argument_group("Socket options")
-    group.add_argument("--socket-recv-size", type=int,
-                       help="When using raw sockets, specify the size of the buffer used to receive packets with socket.recv.")
+    group.add_argument(
+        "--socket-recv-size",
+        type=int,
+        help="When using raw sockets, specify the size of the buffer used to receive packets with socket.recv.",
+    )
 
     # Might need this if other parsers want command line
     # parser.allow_interspersed_args = False
@@ -326,6 +410,7 @@ be subtracted from the result by prefixing them with the '^' character.  """
 
     return (config, args)
 
+
 def logging_setup(config):
     """
     Set up logging based on config
@@ -336,13 +421,15 @@ def logging_setup(config):
     if config["log_dir"] != None:
         if os.path.exists(config["log_dir"]):
             import shutil
+
             shutil.rmtree(config["log_dir"])
         os.makedirs(config["log_dir"])
     else:
         if os.path.exists(config["log_file"]):
             os.remove(config["log_file"])
 
-    ptf.open_logfile('main')
+    ptf.open_logfile("main")
+
 
 def xunit_setup(config):
     """
@@ -354,8 +441,10 @@ def xunit_setup(config):
 
     if os.path.exists(config["xunit_dir"]):
         import shutil
+
         shutil.rmtree(config["xunit_dir"])
     os.makedirs(config["xunit_dir"])
+
 
 def pcap_setup(config):
     """
@@ -363,11 +452,12 @@ def pcap_setup(config):
     """
 
     if config["log_dir"] == None:
-        filename = os.path.splitext(config["log_file"])[0] + '.pcap'
+        filename = os.path.splitext(config["log_file"])[0] + ".pcap"
         ptf.dataplane_instance.start_pcap(filename)
     else:
         # start_pcap is called per-test in base_tests
         pass
+
 
 def profiler_setup(config):
     """
@@ -378,10 +468,12 @@ def profiler_setup(config):
         return
 
     import cProfile
+
     profiler = cProfile.Profile()
     profiler.enable()
 
     return profiler
+
 
 def profiler_teardown(profiler):
     """
@@ -412,9 +504,9 @@ def load_test_modules(config):
     result = OrderedDict()
 
     for root, dirs, filenames in os.walk(config["test_dir"]):
-        pyfiles = fnmatch.filter(filenames, '[!.]*.py')
+        pyfiles = fnmatch.filter(filenames, "[!.]*.py")
         if len(pyfiles) == 0:
-            continue;
+            continue
 
         # Allow tests to import each other
         sys.path.append(root)
@@ -432,11 +524,14 @@ def load_test_modules(config):
                 logging.warning("Could not import file " + filename)
                 raise
 
-
             # Find all testcases defined in the module
-            tests = dict((k, v) for (k, v) in mod.__dict__.items() if type(v) == type and
-                                                                      issubclass(v, unittest.TestCase) and
-                                                                      hasattr(v, "runTest"))
+            tests = dict(
+                (k, v)
+                for (k, v) in mod.__dict__.items()
+                if type(v) == type
+                and issubclass(v, unittest.TestCase)
+                and hasattr(v, "runTest")
+            )
             if tests:
                 for (testname, test) in tests.items():
                     # Set default annotation values
@@ -463,11 +558,12 @@ def load_test_modules(config):
                     # Put test in the standard test group
                     if not test._disabled and not test._nonstandard:
                         test._groups.append("standard")
-                        test._groups.append("all") # backwards compatibility
+                        test._groups.append("all")  # backwards compatibility
 
                 result[modname] = (mod, tests)
 
     return result
+
 
 def prune_tests(test_specs, test_modules):
     """
@@ -480,7 +576,7 @@ def prune_tests(test_specs, test_modules):
     for e in test_specs:
         matched = False
 
-        if e.startswith('^'):
+        if e.startswith("^"):
             negated = True
             e = e[1:]
         else:
@@ -505,9 +601,11 @@ def prune_tests(test_specs, test_modules):
 
     return result
 
+
 def die(msg, exit_val=1):
     logging.critical(msg)
     sys.exit(exit_val)
+
 
 def _space_to(n, str):
     """
@@ -519,11 +617,11 @@ def _space_to(n, str):
         return " " * spaces
     return " "
 
+
 def test_params_parse(config):
     test_params = config["test_params"]
     if test_params is None:
-        logging.debug(
-            "No test params were provided with '--test-params' / '-t'")
+        logging.debug("No test params were provided with '--test-params' / '-t'")
         return None
     params_str = "class _TestParams:\n    " + test_params
     namespace = {}
@@ -534,18 +632,21 @@ def test_params_parse(config):
             "Error when parsing test params "
             "(provided with '--test-params' / '-t'). "
             "Make sure you used the correct syntax: "
-            "--test-params=\"[k=v;]*k=v\"")
+            '--test-params="[k=v;]*k=v"'
+        )
         return None
     params = {}
     logging.debug("Parsed test parameters:")
-    for k, v in list(vars(namespace['_TestParams']).items()):
+    for k, v in list(vars(namespace["_TestParams"]).items()):
         if k[:2] != "__":
             params[k] = v
             logging.debug("\t*{}={}".format(k, v))
     logging.debug(
         "If something is missing, make sure you used the correct syntax: "
-        "--test-params=\"[k=v;]*k=v\"")
+        '--test-params="[k=v;]*k=v"'
+    )
     return params
+
 
 #
 # Main script
@@ -572,9 +673,9 @@ ptf.testutils.PORT_INFO = config["port_info"]
 
 test_specs = args.test_specs
 if config["test_file"] != None:
-    with open(config["test_file"], 'r') as f:
+    with open(config["test_file"], "r") as f:
         for line in f:
-            line, _, _ = line.partition('#') # remove comments
+            line, _, _ = line.partition("#")  # remove comments
             line = line.strip()
             if line:
                 test_specs.append(line)
@@ -588,25 +689,29 @@ if config["list"]:
     mod_count = 0
     test_count = 0
     all_groups = set()
-    print("""\
+    print(
+        """\
 Tests are shown grouped by module. If a test is in any groups beyond "standard"
-and its module's group then they are shown in parentheses.""")
+and its module's group then they are shown in parentheses."""
+    )
     print()
-    print("""\
+    print(
+        """\
 Tests marked with '!' are disabled because they are experimental, special-purpose,
 or are too long to be run normally. These are not part of the "standard" test
-group or their module's test group.""")
+group or their module's test group."""
+    )
     print()
     print("Test List:")
     for (modname, (mod, tests)) in test_modules.items():
         mod_count += 1
-        desc = (mod.__doc__ or "No description").strip().split('\n')[0]
+        desc = (mod.__doc__ or "No description").strip().split("\n")[0]
         start_str = "  Module " + mod.__name__ + ": "
         print(start_str + _space_to(22, start_str) + desc)
         for (testname, test) in list(tests.items()):
             try:
                 desc = (test.__doc__ or "").strip()
-                desc = desc.split('\n')[0]
+                desc = desc.split("\n")[0]
             except:
                 desc = "No description"
             groups = set(test._groups) - set(["all", "standard", modname])
@@ -615,18 +720,19 @@ group or their module's test group.""")
                 desc = "(%s) %s" % (",".join(groups), desc)
             if hasattr(test, "_versions"):
                 desc = "(%s) %s" % (",".join(sorted(test._versions)), desc)
-            start_str = " %s%s %s:" % (test._nonstandard and "*" or " ",
-                                       test._disabled and "!" or " ",
-                                       testname)
+            start_str = " %s%s %s:" % (
+                test._nonstandard and "*" or " ",
+                test._disabled and "!" or " ",
+                testname,
+            )
             if len(start_str) > 22:
                 desc = "\n" + _space_to(22, "") + desc
             print(start_str + _space_to(22, start_str) + desc)
             test_count += 1
         print()
-    print("%d modules shown with a total of %d tests" % \
-        (mod_count, test_count))
+    print("%d modules shown with a total of %d tests" % (mod_count, test_count))
     print()
-    print("Test groups: %s" % (', '.join(sorted(all_groups))))
+    print("Test groups: %s" % (", ".join(sorted(all_groups))))
 
     sys.exit(0)
 
@@ -654,6 +760,7 @@ elif config["test_order"] == "rand":
 
 if config["platform_dir"] is None:
     from ptf import platforms
+
     config["platform_dir"] = os.path.dirname(os.path.abspath(platforms.__file__))
 
 # Allow platforms to import each other
@@ -672,7 +779,9 @@ if platform_name == "nn":
 
 platform_mod = None
 try:
-    platform_mod = imp.load_module(platform_name, *imp.find_module(platform_name, [config["platform_dir"]]))
+    platform_mod = imp.load_module(
+        platform_name, *imp.find_module(platform_name, [config["platform_dir"]])
+    )
 except:
     logging.warn("Failed to import " + platform_name + " platform module")
     raise
@@ -691,7 +800,7 @@ logging.info("port map: " + str(config["port_map"]))
 
 ptf.ptfutils.default_timeout = config["default_timeout"]
 ptf.ptfutils.default_negative_timeout = config["default_negative_timeout"]
-ptf.testutils.MINSIZE = config['minsize']
+ptf.testutils.MINSIZE = config["minsize"]
 
 if os.getuid() != 0 and not config["allow_user"] and platform_name != "nn":
     die("Super-user privileges required. Please re-run with sudo or as root.")
@@ -727,9 +836,9 @@ if __name__ == "__main__":
             ptf.dataplane_instance.kill()
             profiler_teardown(profiler)
             raise ex
-        runner = xmlrunner.XMLTestRunner(output=config["xunit_dir"],
-                                         outsuffix="",
-                                         verbosity=2)
+        runner = xmlrunner.XMLTestRunner(
+            output=config["xunit_dir"], outsuffix="", verbosity=2
+        )
     else:
         runner = unittest.TextTestRunner(verbosity=2)
     test_case_timeout = config["test_case_timeout"]
@@ -737,6 +846,7 @@ if __name__ == "__main__":
     run_errors = []
     run_timeouts = []
     from ptf.ptfutils import Timeout
+
     for t in test_suite:
         if t._testtimeout is not None:
             this_test_timeout = t._testtimeout
@@ -764,7 +874,7 @@ if __name__ == "__main__":
             logging.info("Test failed and failfast mode enabled, stopping")
             break
 
-    ptf.open_logfile('main')
+    ptf.open_logfile("main")
     if ptf.testutils.skipped_test_count > 0:
         ts = " tests"
         if ptf.testutils.skipped_test_count == 1:
@@ -804,8 +914,7 @@ if __name__ == "__main__":
     if ptf.testutils.skipped_test_count > 0 and config["fail_skipped"]:
         print()
         print("******************************************")
-        print("ATTENTION: %d TESTS WERE SKIPPED!!!",
-                ptf.testutils.skipped_test_count)
+        print("ATTENTION: %d TESTS WERE SKIPPED!!!", ptf.testutils.skipped_test_count)
         print("******************************************")
         print()
         sys.stdout.flush()


### PR DESCRIPTION
Add a `ptf` file for the Black watch.

Excluded still will be `example`, `ptf_nn` & `utests` (additional work with the files to be cross-compatible with Py3, need to be done).