### PR TITLE
Add support for sharding

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,19 @@ sudo ./ptf <other parameters> -pmm foo.packet_foo
 Please make sure that this module is loaded into the runtime before running 
 any tests.
 
+## Sharding
+
+You can achieve parallelization by splitting tests into N groups and running them with separate PTF processes.
+Each PTF instance will run disjoint subset of all selected tests.
+
+For example to run specific set of tests across 3 PTF instances:
+
+```
+$ ssh mynode0 sudo ./ptf --test-dir mytests --num-shards 3 --shard-id 0 all ^other &
+$ ssh mynode1 sudo ./ptf --test-dir mytests --num-shards 3 --shard-id 1 all ^other &
+$ ssh mynode2 sudo ./ptf --test-dir mytests --num-shards 3 --shard-id 2 all ^other &
+```
+
 ---
 
 # Configuring PTF

--- a/ptf
+++ b/ptf
@@ -59,6 +59,8 @@ config_default = {
     "test_dir": None,
     "test_order": "default",
     "test_order_seed": 0xABA,
+    "num_shards": 1,
+    "shard_id": 0,
     # Switch connection options
     "platform": "eth",
     "platform_args": None,
@@ -268,6 +270,12 @@ be subtracted from the result by prefixing them with the '^' character.  """
     )
     group.add_argument(
         "--test-order-seed", type=int, help="Specify seed to randomize test order"
+    )
+    group.add_argument(
+        "--num-shards", type=int, help="Number of shards that can be used to parallelize test execution"
+    )
+    group.add_argument(
+        "--shard-id", type=int, help="Index of shard (>= 0 and < number of shards)"
     )
 
     group = parser.add_argument_group("Switch connection options")
@@ -760,6 +768,11 @@ test_suite = []
 for (modname, (mod, tests)) in test_modules.items():
     for (testname, test) in tests.items():
         test_suite.append(test())
+
+if config["shard_id"] < 0 or config["shard_id"] >= config["num_shards"]:
+    die("shard id should be equal or greater than 0 and lower than number of shards")
+test_suite = test_suite[config["shard_id"]::config["num_shards"]]
+
 if config["test_order"] == "lexico":
     test_suite.sort()
 elif config["test_order"] == "rand":

--- a/ptf
+++ b/ptf
@@ -272,7 +272,9 @@ be subtracted from the result by prefixing them with the '^' character.  """
         "--test-order-seed", type=int, help="Specify seed to randomize test order"
     )
     group.add_argument(
-        "--num-shards", type=int, help="Number of shards that can be used to parallelize test execution"
+        "--num-shards",
+        type=int,
+        help="Number of shards that can be used to parallelize test execution",
     )
     group.add_argument(
         "--shard-id", type=int, help="Index of shard (>= 0 and < number of shards)"
@@ -771,7 +773,7 @@ for (modname, (mod, tests)) in test_modules.items():
 
 if config["shard_id"] < 0 or config["shard_id"] >= config["num_shards"]:
     die("shard id should be equal or greater than 0 and lower than number of shards")
-test_suite = test_suite[config["shard_id"]::config["num_shards"]]
+test_suite = test_suite[config["shard_id"] :: config["num_shards"]]
 
 if config["test_order"] == "lexico":
     test_suite.sort()


### PR DESCRIPTION
From now, it is possible to achieve parallelization by splitting tests into N groups and running them with separate PTF processes.
Each PTF instance will run disjoint subset of all selected tests.