### PR TITLE
Expose ERSPAN_III flags in testutils functions

### DIFF
--- a/src/ptf/testutils.py
+++ b/src/ptf/testutils.py
@@ -1441,13 +1441,19 @@ def ipv4_erspan_pkt(
     version=2,
     mirror_id=0x3FF,
     sgt_other=0,
+    erspan_p=0,
+    erspan_ft=0,
+    erspan_hw=0,
+    erspan_d=0,
+    erspan_gra=0,
+    erspan_o=0,
     inner_frame=None,
 ):
     """
     Return a GRE ERSPAN packet
 
     Supports a few parameters:
-    @param len Length of packet in bytes w/o CRC
+    @param pktlen Length of packet in bytes w/o CRC
     @param eth_dst Destination MAC
     @param eth_src Source MAC
     @param dl_vlan_enable True if the packet is with vlan, False otherwise
@@ -1461,8 +1467,17 @@ def ipv4_erspan_pkt(
     @param ip_ttl IP TTL
     @param ip_id IP ID
     @param ip_flags IP Flags
-    @param erspan version
-    @param span_id (mirror_session_id)
+    @param ip_ihl IP ihl
+    @param ip_options list of IP options (False if don't want to)
+    @param version ERSPAN version
+    @param mirror_id (mirror_session_id)
+    @param sgt_other for ERSPAN_III it is sgt field
+    @param erspan_p ERSPAN_III p field
+    @param erspan_ft ERSPAN_III ft field
+    @param erspan_hw ERSPAN_III hw field
+    @param erspan_d ERSPAN_III d field
+    @param erspan_gra ERSPAN_III gra field
+    @param erspan_o ERSPAN_III o field
     @param inner_frame payload of the GRE packet
     """
     if packet.GRE is None or packet.ERSPAN is None or packet.ERSPAN_III is None:
@@ -1476,7 +1491,14 @@ def ipv4_erspan_pkt(
 
     if version == 2:
         erspan_hdr = packet.GRE(proto=0x22EB) / packet.ERSPAN_III(
-            session_id=mirror_id, sgt_other=sgt_other
+            session_id=mirror_id,
+            sgt_other=sgt_other,
+            p=erspan_p,
+            ft=erspan_ft,
+            hw=erspan_hw,
+            d=erspan_d,
+            gra=erspan_gra,
+            o=erspan_o,
         )
     else:
         erspan_hdr = packet.GRE(proto=0x88BE) / packet.ERSPAN(session_id=mirror_id)
@@ -1560,6 +1582,12 @@ def ipv4_erspan_platform_pkt(
     version=2,
     mirror_id=0x3FF,
     sgt_other=1,
+    erspan_p=0,
+    erspan_ft=0,
+    erspan_hw=0,
+    erspan_d=0,
+    erspan_gra=0,
+    erspan_o=1,
     platf_id=0,
     info1=0,
     info2=0,
@@ -1569,7 +1597,7 @@ def ipv4_erspan_platform_pkt(
     Return a GRE ERSPAN packet with Platform Specific Subheader
 
     Supports a few parameters:
-    @param len Length of packet in bytes w/o CRC
+    @param pktlen Length of packet in bytes w/o CRC
     @param eth_dst Destination MAC
     @param eth_src Source MAC
     @param dl_vlan_enable True if the packet is with vlan, False otherwise
@@ -1583,8 +1611,17 @@ def ipv4_erspan_platform_pkt(
     @param ip_ttl IP TTL
     @param ip_id IP ID
     @param ip_flags IP Flags
-    @param erspan version
-    @param span_id (mirror_session_id)
+    @param ip_ihl IP ihl
+    @param ip_options list of IP options (False if don't want to)
+    @param version ERSPAN version
+    @param mirror_id (mirror_session_id)
+    @param sgt_other for ERSPAN_III it is sgt field
+    @param erspan_p ERSPAN_III p field
+    @param erspan_ft ERSPAN_III ft field
+    @param erspan_hw ERSPAN_III hw field
+    @param erspan_d ERSPAN_III d field
+    @param erspan_gra ERSPAN_III gra field
+    @param erspan_o ERSPAN_III o field
     @param platf_id Specific Platform Subheader Platf Id
     @param info1 Specific Platform Subheader 26 bit field
     @param info2 Specific Platform Subheader 32 bit field
@@ -1606,7 +1643,14 @@ def ipv4_erspan_platform_pkt(
 
     if version == 2:
         erspan_hdr = packet.GRE(proto=0x22EB) / packet.ERSPAN_III(
-            session_id=mirror_id, sgt_other=sgt_other
+            session_id=mirror_id,
+            sgt_other=sgt_other,
+            p=erspan_p,
+            ft=erspan_ft,
+            hw=erspan_hw,
+            d=erspan_d,
+            gra=erspan_gra,
+            o=erspan_o,
         )
         if sgt_other & 0x01 == 1:
             erspan_hdr = erspan_hdr / packet.PlatformSpecific(


### PR DESCRIPTION
At this moment, functions `ipv4_erspan_pkt` and `ipv4_erspan_platform_pkt` in testutils do not expose flag fields of ERSPAN_III: `p`, `ft`, `hw`, `d`, `gra` and `o`.

This PR adds to these functions arguments for these flags, keeping backward compatibility with `sgt_other` field.