### PR TITLE
Potential fix for scapy'ies conditional field mask (for #162)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ with open("requirements.txt", "r") as req:
 
 setup(
     name='ptf',
-    version='0.9.1',
+    version='0.9.2',
     description='PTF is a Python based dataplane test framework.',
     long_description=readme,
     long_description_content_type="text/markdown",

--- a/src/ptf/mask.py
+++ b/src/ptf/mask.py
@@ -1,7 +1,7 @@
 from __future__ import print_function
 import warnings
 
-from six import StringIO, PY2
+from six import StringIO
 import sys
 from . import packet
 
@@ -23,12 +23,6 @@ class Mask:
             self.mask[offsetB] = self.mask[offsetB] & (~(1 << (7 - offsetb)))
 
     def set_do_not_care_packet(self, hdr_type, field_name):
-        def get_raw_packet():
-            if PY2:
-                if hasattr(self.exp_pkt[hdr_type], "__bytes__"):
-                    return self.exp_pkt[hdr_type].__bytes__()
-            return bytes(self.exp_pkt[hdr_type])
-
         if hdr_type not in self.exp_pkt:
             self.valid = False
             print("Unknown header type")
@@ -38,7 +32,7 @@ class Mask:
                 field
                 for field in hdr_type.fields_desc
                 if field.name
-                in self.exp_pkt[hdr_type].__class__(get_raw_packet()).fields.keys()
+                in self.exp_pkt[hdr_type].__class__(bytes(self.exp_pkt[hdr_type])).fields.keys()
             ]  # build & read packet to be sure, all fields are correctly filed
         except Exception:  # noqa
             self.valid = False

--- a/src/ptf/mask.py
+++ b/src/ptf/mask.py
@@ -32,7 +32,9 @@ class Mask:
                 field
                 for field in hdr_type.fields_desc
                 if field.name
-                in self.exp_pkt[hdr_type].__class__(bytes(self.exp_pkt[hdr_type])).fields.keys()
+                in self.exp_pkt[hdr_type]
+                .__class__(bytes(self.exp_pkt[hdr_type]))
+                .fields.keys()
             ]  # build & read packet to be sure, all fields are correctly filed
         except Exception:  # noqa
             self.valid = False

--- a/src/ptf/mask.py
+++ b/src/ptf/mask.py
@@ -34,14 +34,12 @@ class Mask:
             print("Unknown header type")
             return
         try:
-            fields_desc = hdr_type.fields_desc
-            if self.exp_pkt[hdr_type].fields:
-                fields_desc = [
-                    field
-                    for field in hdr_type.fields_desc
-                    if field.name
-                    in self.exp_pkt[hdr_type].__class__(get_raw_packet()).fields.keys()
-                ]
+            fields_desc = [
+                field
+                for field in hdr_type.fields_desc
+                if field.name
+                in self.exp_pkt[hdr_type].__class__(get_raw_packet()).fields.keys()
+            ]  # build & read packet to be sure, all fields are correctly filed
         except Exception:  # noqa
             self.valid = False
             return

--- a/src/ptf/mask.py
+++ b/src/ptf/mask.py
@@ -35,7 +35,7 @@ class Mask:
                 in self.exp_pkt[hdr_type]
                 .__class__(bytes(self.exp_pkt[hdr_type]))
                 .fields.keys()
-            ]  # build & read packet to be sure, all fields are correctly filed
+            ]  # build & parse packet to be sure all fields are correctly filled
         except Exception:  # noqa
             self.valid = False
             return

--- a/utests/tests/ptf/test_mask.py
+++ b/utests/tests/ptf/test_mask.py
@@ -37,3 +37,19 @@ class TestMask:
         assert (
             masked_simple_vxlan.mask != second_masked_packet.mask
         ), "Masks should not be equal"
+
+    def test_mask__mask_has_problem_with_conditional_fields(self):
+        pkt = VXLAN(flags=0x80, gpflags=0x23, gpid=0x1234, vni=0x1337)
+        mask_pkt = Mask(pkt)
+        mask_pkt.set_do_not_care_packet(VXLAN, "gpid")
+
+        assert mask_pkt.mask == [
+            255,
+            255,
+            0,
+            0,
+            255,
+            255,
+            255,
+            255,
+        ], "Only gpid field should be masked"


### PR DESCRIPTION
Closes: #162

## Issue:
Some Scapy'ies Packets contain  `Conditional Fields`, like `VXLAN`. 
The previous mechanism tries to find elements to mask, using a `field_desc` which represents the entire raw packet with all options, not a specific version of the packet.

All the fields that were taken by the mechanism:
```text
["flags <class 'scapy.fields.FlagsField'>", 
"reserved0 <class 'scapy.fields.ConditionalField'>", 
"NextProtocol <class 'scapy.fields.ConditionalField'>", 
"reserved1 <class 'scapy.fields.ConditionalField'>", 
"gpflags <class 'scapy.fields.ConditionalField'>", 
"gpid <class 'scapy.fields.ConditionalField'>", 
"vni <class 'scapy.fields.X3BytesField'>", 
"reserved2 <class 'scapy.fields.XByteField'>"]
```

when we provide such example:
```
VXLAN(flags=0x80, gpflags=0x23, gpid=0x1234, vni=0x1337)
```

Scapy will create a packet with `gpflags` & `gpid`. The `nextprotocol` will be skipped. Old mechanism to mask fields, calculate base on the information from `fields_desc` not from only available after the `build` packet process, which causes `IndexError` and masking the wrong fields. 

Valid fields that should be taken into account by the mechanism:
```text
["flags <class 'scapy.fields.FlagsField'>", 
"gpflags <class 'scapy.fields.ConditionalField'>", 
"gpid <class 'scapy.fields.ConditionalField'>", 
"vni <class 'scapy.fields.X3BytesField'>", 
"reserved2 <class 'scapy.fields.XByteField'>"]
```

After this change, we locate the fields based on the finished, built package.
