### PR TITLE
Add coverage to requirements-dev.txt and enable it at pipeline

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,4 @@
 # Config file for automatic testing using github actions
-#
 
 name: Unit_Tests
 
@@ -24,7 +23,10 @@ jobs:
           make format-check
       - name: Run pytests (utests/tests)
         run: | 
-          make test
+          make coverage
+      - name: Check coverage (src/)
+        run: |
+          make coverage-check
   test:
     runs-on: ubuntu-18.04
     steps:

--- a/Makefile
+++ b/Makefile
@@ -17,3 +17,16 @@ set-dev:
 test:
 	@echo "Running tests..."
 	export PYTHONPATH=${PWD}/src && python -m pytest utests/
+
+.PHONY: coverage
+coverage:
+	@echo "Running tests with coverage..."
+	export PYTHONPATH=${PWD}/src && python -m coverage run --source src/ -m pytest utests/
+
+.PHONY: coverage-check
+coverage-check:
+	@echo "Checking coverage..."
+	python -m coverage report --fail-under=28
+
+.PHONY: coverage-all
+coverage-all: coverage coverage-check

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,3 +2,4 @@
 
 black==21.7b0
 pytest==6.2.5
+coverage==6.2


### PR DESCRIPTION
Coverage check at the pipeline, will **fail under 28%**. 

```text
Checking coverage...
python -m coverage report --fail-under=28
Name                            Stmts   Miss  Cover
---------------------------------------------------
src/ptf/__init__.py                27     17    37%
src/ptf/afpacket.py                50     28    44%
src/ptf/base_tests.py              20     20     0%
src/ptf/dataplane.py              488    349    28%
src/ptf/mask.py                    70     24    66%
src/ptf/netutils.py                26     11    58%
src/ptf/packet.py                   9      1    89%
src/ptf/packet_scapy.py           121     23    81%
src/ptf/parse.py                   40     33    18%
src/ptf/pcap_writer.py             24     14    42%
src/ptf/platforms/__init__.py       0      0   100%
src/ptf/platforms/dummy.py          2      2     0%
src/ptf/platforms/eth.py            7      7     0%
src/ptf/platforms/local.py          9      9     0%
src/ptf/platforms/nn.py             6      6     0%
src/ptf/platforms/remote.py         4      4     0%
src/ptf/ptfutils.py                64     41    36%
src/ptf/testutils.py              855    701    18%
src/ptf/thriftutils.py             70     70     0%
---------------------------------------------------
TOTAL                            1892   1360    28%
```