### PR TITLE
Guarantee that tests are loaded in stable order

### DIFF
--- a/ptf
+++ b/ptf
@@ -525,6 +525,11 @@ def load_test_modules(config):
 
     for root, dirs, filenames in os.walk(config["test_dir"]):
         pyfiles = fnmatch.filter(filenames, "[!.]*.py")
+
+        # guarantee that files will be visited in the same order every time tests are loaded
+        pyfiles.sort()
+        dirs.sort()
+
         if len(pyfiles) == 0:
             continue
 


### PR DESCRIPTION
Default behavior of `--test-order` option is described as:
> tests are run in the order in which they appear on command line

In case `test_specs` contains only group names, the order of tests within the single group is not defined and may depend on filesystem implementation. 

To avoid this issue files/directories should be visited in a stable order.
