### PR TITLE
Upgrade black version to 22.3.0

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
 -r requirements.txt
 
-black==21.7b0
+black==22.3.0
 pytest==6.2.5


### PR DESCRIPTION
Due to problem in `black` with incompatibility with `click v8.1.0` (https://github.com/psf/black/issues/2964) PTF CI started to fail on format check. 
According to the link, the solution is to upgrade `black` to version `22.3.0`.