### PR TITLE
Add a send timeout to nnpy sockets.

### DIFF
--- a/src/ptf/dataplane.py
+++ b/src/ptf/dataplane.py
@@ -232,6 +232,9 @@ class DataPlanePacketSourceNN(DataPlanePacketSourceIface):
         self.socket.connect(socket_addr)
         self.rcv_timeout = rcv_timeout
         self.socket.setsockopt(nnpy.SOL_SOCKET, nnpy.RCVTIMEO, rcv_timeout)
+        # Time out after a second if the socket is non-functional.
+        # This should be long enough for nanomsg.
+        self.socket.setsockopt(nnpy.SOL_SOCKET, nnpy.SNDTIMEO, 1000)
         self.buffers = defaultdict(list)
         self.cvar = Condition()
         self.mac_addresses = {}


### PR DESCRIPTION
If the nanomsg peer has crashed or is otherwise non-function, nanomsg will block indefinitely on send. This PR adds a socket option with a (conservative) timeout. 

Fixes #178. 