### PR TITLE
Remove several mentions of Python 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ More information about Black, you find at
 
 The following software is required to run PTF:
 
- * Python 2.7 or 3.x
+ * Python 3.x
  * six 1.16.0
  * Scapy 2.4.5 (unless you provide another packet manipulation module)
  * pypcap (optional - VLAN tests will fail without this)

--- a/ptf_nn/ptf_nn_agent.py
+++ b/ptf_nn/ptf_nn_agent.py
@@ -305,10 +305,7 @@ class NanomsgMgr(threading.Thread):
         msg = struct.pack("<iii{}s".format(len(p)), self.MSG_TYPE_PACKET_OUT,
                           port, len(p), p)
         # because nnpy expects unicode when using str
-        if sys.version_info[0] == 2:
-            msg = list(bytes(msg))
-        else:
-            msg = bytearray(msg)
+        msg = bytearray(msg)
 
         self.socket.send(msg)
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,7 +19,7 @@ package_dir=
 packages = find:
 scripts = ptf, ptf_nn/ptf_nn_agent.py
 platforms = any
-python_requires = >=2.7, >=3
+python_requires = >=3
 setup_requires =
     setuptools_scm
 install_requires = file: requirements.txt

--- a/src/ptf/dataplane.py
+++ b/src/ptf/dataplane.py
@@ -321,10 +321,7 @@ class DataPlanePacketSourceNN(DataPlanePacketSourceIface):
             packet,
         )
         # because nnpy expects unicode when using str
-        if sys.version_info[0] == 2:
-            msg = list(msg)
-        else:
-            msg = bytearray(msg)
+        msg = bytearray(msg)
         self.socket.send(msg)
         # nnpy does not return the number of bytes sent
         return len(packet)

--- a/src/ptf/testutils.py
+++ b/src/ptf/testutils.py
@@ -3179,7 +3179,7 @@ def ptf_ports(num=None):
 
 
 def port_to_tuple(port):
-    if type(port) is int or (sys.version_info[0] == 2 and type(port) is int):
+    if type(port) is int:
         return 0, port
     if type(port) is tuple:
         return port


### PR DESCRIPTION
Not all of them are removed with these changes, because I am not sure how best to remove some of them, e.g. in the file debian/control