### PR TITLE
Add flags option to nanomsg port msg calls. Make port_remove non-blocking.

### DIFF
--- a/src/ptf/dataplane.py
+++ b/src/ptf/dataplane.py
@@ -321,10 +321,7 @@ class DataPlanePacketSourceNN(DataPlanePacketSourceIface):
             packet,
         )
         # because nnpy expects unicode when using str
-        if sys.version_info[0] == 2:
-            msg = list(msg)
-        else:
-            msg = bytearray(msg)
+        msg = bytearray(msg)
         self.socket.send(msg)
         # nnpy does not return the number of bytes sent
         return len(packet)


### PR DESCRIPTION
A little change to make sure clean up is somewhat non-blocking. There are some cases where cleanup can take a really long time. This is because `__del__` tries to remove every single port synchronously, which gets slow for several hundred ports. Ideally, cleanup should be done in bulk by deleting all ports at once, but the current setup does not seem to support this.  