### PR TITLE
Fix setup.cfg format issue to match old setuptools versions.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -22,7 +22,6 @@ platforms = any
 python_requires = >=3
 setup_requires =
     setuptools_scm
-install_requires = file: requirements.txt
 
 [options.packages.find]
 where = src


### PR DESCRIPTION
```
install_requires = file: requirements.txt
```
This kind of format will break old setuptools versions.
Currently requirements.txt is empty. Maybe it's better to remove this line temporarily.