### PR TITLE
Replace occurrences of scapy with pktmanip for "packet manipulation module"

### DIFF
--- a/ptf
+++ b/ptf
@@ -389,32 +389,32 @@ be subtracted from the result by prefixing them with the '^' character.  """
     group.add_argument(
         "--disable-vxlan",
         action="store_true",
-        help="Disable VXLAN (do not import from scapy even if supported)",
+        help="Disable VXLAN (do not import from pktmanip module even if supported)",
     )
     group.add_argument(
         "--disable-geneve",
         action="store_true",
-        help="Disable GENEVE (do not import from scapy even if supported)",
+        help="Disable GENEVE (do not import from pktmanip module even if supported)",
     )
     group.add_argument(
         "--disable-erspan",
         action="store_true",
-        help="Disable ERSPAN (do not import from scapy even if supported)",
+        help="Disable ERSPAN (do not import from pktmanip module even if supported)",
     )
     group.add_argument(
         "--disable-mpls",
         action="store_true",
-        help="Disable MPLS (do not import from scapy even if supported)",
+        help="Disable MPLS (do not import from pktmanip module even if supported)",
     )
     group.add_argument(
         "--disable-nvgre",
         action="store_true",
-        help="Disable NVGRE (do not import from scapy even if supported)",
+        help="Disable NVGRE (do not import from pktmanip module even if supported)",
     )
     group.add_argument(
         "--disable-igmp",
         action="store_true",
-        help="Disable IGMP (do not import from scapy even if supported)",
+        help="Disable IGMP (do not import from pktmanip module even if supported)",
     )
 
     group = parser.add_argument_group("Socket options")
@@ -693,8 +693,9 @@ logging_setup(config)
 xunit_setup(config)
 logging.info("++++++++ " + time.asctime() + " ++++++++")
 
-# import after logging is configured so that scapy error logs (from importing
-# packet.py) are silenced and our own warnings are logged properly.
+# import after logging is configured so that pktmanip module error
+# logs (from importing packet.py) are silenced and our own warnings
+# are logged properly.
 import ptf.testutils
 
 # Try parsing test params and log them

--- a/ptf_nn/ptf_nn_test_bridge.py
+++ b/ptf_nn/ptf_nn_test_bridge.py
@@ -22,7 +22,7 @@
 
 import argparse
 import threading
-import scapy.all as sc
+import ptf.packet as pktmanip
 import time
 
 parser = argparse.ArgumentParser(description="PTF Nanomsg tester bridge")
@@ -43,11 +43,11 @@ class Forwarder(threading.Thread):
 
     def forward(self, p):
         print("forwarding", p, "---", self.other, "->", self.iface_name)
-        sc.sendp(p, iface=self.iface_name, verbose=0)
+        pktmanip.sendp(p, iface=self.iface_name, verbose=0)
 
     def run(self):
         other_fwd = forwarders[self.other]
-        sc.sniff(iface=self.iface_name, prn=lambda x: other_fwd.forward(x))
+        pktmanip.sniff(iface=self.iface_name, prn=lambda x: other_fwd.forward(x))
 
 
 def main():

--- a/ptf_nn/ptf_nn_test_eth.py
+++ b/ptf_nn/ptf_nn_test_eth.py
@@ -21,7 +21,7 @@
 #
 
 import argparse
-import scapy.all as sc
+import ptf.packet as pktmanip
 
 parser = argparse.ArgumentParser(description="PTF Nanomsg tester 2")
 parser.add_argument("--interface", type=str, dest="interface")
@@ -33,7 +33,7 @@ def receive(interface):
     def printp(p):
         print("Received:", p)
 
-    sc.sniff(iface=interface, prn=lambda x: printp(x))
+    pktmanip.sniff(iface=interface, prn=lambda x: printp(x))
 
 
 def main():
@@ -41,7 +41,7 @@ def main():
         receive(args.interface)
     else:  # send one
         p = "ab" * 20
-        sc.sendp(p, iface=args.interface, verbose=0)
+        pktmanip.sendp(p, iface=args.interface, verbose=0)
 
 
 if __name__ == "__main__":

--- a/src/ptf/dataplane.py
+++ b/src/ptf/dataplane.py
@@ -30,7 +30,7 @@ from threading import Condition
 from . import ptfutils
 from . import netutils
 from . import mask
-from . import packet
+import ptf.packet as pktmanip
 from .pcap_writer import PcapWriter
 from io import StringIO
 
@@ -805,22 +805,23 @@ class DataPlane(Thread):
         def format(self):
             """
             Returns a string containing a nice (but verbose) representation of
-            this packet. If the expected packet is a scapy packet, it's used to
+            this packet. If the expected packet is a pktmanip.Packet object, it's used to
             include detailed information about the fields in the packet.
             """
             try:
                 stdout_save = sys.stdout
-                # The scapy packet dissection methods print directly to stdout,
-                # so we have to redirect stdout to a string.
+                # The pktmanip packet dissection methods print
+                # directly to stdout, so we have to redirect stdout to
+                # a string.
                 sys.stdout = StringIO()
 
                 print("========== RECEIVED ==========")
-                if isinstance(self.expected_packet, packet.Packet):
+                if isinstance(self.expected_packet, pktmanip.Packet):
                     # Dissect this packet as if it were an instance of
                     # the expected packet's class.
-                    packet.ls(self.expected_packet.__class__(self.packet))
+                    pktmanip.ls(self.expected_packet.__class__(self.packet))
                     print("--")
-                packet.hexdump(self.packet)
+                pktmanip.hexdump(self.packet)
                 print("==============================")
 
                 return sys.stdout.getvalue()
@@ -852,26 +853,27 @@ class DataPlane(Thread):
             """
             Returns a string containing a nice (but verbose) error report based
             on this PollFailure. If there was an expected packet, it's included
-            in the output. If the expected packet is a scapy packet object, the
+            in the output. If the expected packet is a pktmanip.Packet object, the
             output will include information about the fields in the packet.
             """
             try:
                 stdout_save = sys.stdout
-                # The scapy packet dissection methods print directly to stdout,
-                # so we have to redirect stdout to a string.
+                # The pktmanip packet dissection methods print
+                # directly to stdout, so we have to redirect stdout to
+                # a string.
                 sys.stdout = StringIO()
 
                 if self.expected_packet is not None:
                     print("========== EXPECTED ==========")
-                    if isinstance(self.expected_packet, packet.Packet):
-                        packet.ls(self.expected_packet)
+                    if isinstance(self.expected_packet, pktmanip.Packet):
+                        pktmanip.ls(self.expected_packet)
                         print("--")
-                        packet.hexdump(self.expected_packet)
+                        pktmanip.hexdump(self.expected_packet)
                     elif isinstance(self.expected_packet, mask.Mask):
                         print("Mask:")
                         print(self.expected_packet)
                     else:
-                        packet.hexdump(self.expected_packet)
+                        pktmanip.hexdump(self.expected_packet)
 
                 print("========== RECEIVED ==========")
                 if self.recent_packets:
@@ -881,12 +883,12 @@ class DataPlane(Thread):
                     )
                     for recent_packet in self.recent_packets:
                         print("------------------------------")
-                        if isinstance(self.expected_packet, packet.Packet):
+                        if isinstance(self.expected_packet, pktmanip.Packet):
                             # Dissect this packet as if it were an instance of
                             # the expected packet's class.
-                            packet.ls(self.expected_packet.__class__(recent_packet))
+                            pktmanip.ls(self.expected_packet.__class__(recent_packet))
                             print("--")
-                        packet.hexdump(recent_packet)
+                        pktmanip.hexdump(recent_packet)
                 else:
                     print("%d total packets." % self.packet_count)
                 print("==============================")

--- a/src/ptf/mask.py
+++ b/src/ptf/mask.py
@@ -2,7 +2,7 @@ import warnings
 
 from io import StringIO
 import sys
-from . import packet
+import ptf.packet as pktmanip
 
 
 class MaskException(Exception):
@@ -124,9 +124,9 @@ class Mask:
         sys.stdout = buffer = StringIO()
         print("\npacket status: %s" % "OK" if self.valid else "INVALID")
         print("packet:")
-        packet.hexdump(self.exp_pkt)  # noqa
+        pktmanip.hexdump(self.exp_pkt)  # noqa
         print("\npacket's mask:")
-        packet.hexdump(self.mask)  # noqa
+        pktmanip.hexdump(self.mask)  # noqa
 
         sys.stdout = old_stdout
         return buffer.getvalue()

--- a/src/ptf/packet.py
+++ b/src/ptf/packet.py
@@ -1,9 +1,12 @@
 """A pluggable packet module
 
-This module dynamically imports definitions from packet manipulation module,
-specified in config or provided as an agrument.
-The default one is Scapy, but one can develop its own packet manipulation framework and
-then, create an implementation of packet module for it (for Scapy it is packet_scapy.py)
+This module dynamically imports definitions from a designated packet
+manipulation module, specified in config or provided as an argument.
+
+The default one is Scapy, but one can develop their own packet
+manipulation framework and then, create an implementation of a packet
+module for it (for Scapy it is packet_scapy.py)
+
 """
 
 from ptf import config
@@ -13,8 +16,8 @@ __module = __import__(
 )
 __keys = []
 
-# import logic - everything from __all__ if provided, otherwise everything not starting
-# with underscore
+# import logic - everything from __all__ if provided, otherwise
+# everything not starting with underscore
 print("Using packet manipulation module: %s" % __module.__name__)
 if "__all__" in __module.__dict__:
     __keys = __module.__dict__["__all__"]

--- a/src/ptf/parse.py
+++ b/src/ptf/parse.py
@@ -4,7 +4,7 @@ Utility parsing functions
 
 import sys
 import socket
-from . import packet as scapy
+import ptf.packet as pktmanip
 
 
 def parse_mac(mac_str):
@@ -47,32 +47,32 @@ def parse_ipv6(ip_str):
 
 def packet_type_classify(ether):
     try:
-        dot1q = ether[scapy.Dot1Q]
+        dot1q = ether[pktmanip.Dot1Q]
     except:
         dot1q = None
 
     try:
-        ip = ether[scapy.IP]
+        ip = ether[pktmanip.IP]
     except:
         ip = None
 
     try:
-        tcp = ether[scapy.TCP]
+        tcp = ether[pktmanip.TCP]
     except:
         tcp = None
 
     try:
-        udp = ether[scapy.UDP]
+        udp = ether[pktmanip.UDP]
     except:
         udp = None
 
     try:
-        icmp = ether[scapy.ICMP]
+        icmp = ether[pktmanip.ICMP]
     except:
         icmp = None
 
     try:
-        arp = ether[scapy.ARP]
+        arp = ether[pktmanip.ARP]
     except:
         arp = None
     return (dot1q, ip, tcp, udp, icmp, arp)

--- a/utests/tests/ptf/conftest.py
+++ b/utests/tests/ptf/conftest.py
@@ -1,12 +1,10 @@
 import pytest
-from scapy.layers.inet import IP, UDP, TCP
-from scapy.layers.l2 import Ether
-from scapy.layers.vxlan import VXLAN
-from scapy.packet import Packet
+
+from ptf.packet import Ether, IP, UDP, TCP, VXLAN, Packet
 
 
 @pytest.fixture
-def scapy_simple_tcp_packet():  # type: () -> Packet
+def pktmanip_simple_tcp_packet():  # type: () -> Packet
     return (
         Ether(
             dst="00:01:02:03:04:05",
@@ -18,7 +16,7 @@ def scapy_simple_tcp_packet():  # type: () -> Packet
 
 
 @pytest.fixture
-def scapy_simple_vxlan_packet():  # type: () -> Packet
+def pktmanip_simple_vxlan_packet():  # type: () -> Packet
     return (
         Ether(
             dst="00:01:02:03:04:05",

--- a/utests/tests/ptf/test_mask.py
+++ b/utests/tests/ptf/test_mask.py
@@ -1,14 +1,12 @@
 import pytest
-from scapy.layers.inet import IP, TCP, UDP
-from scapy.layers.vxlan import VXLAN
-from scapy.packet import Packet
 
+from ptf.packet import IP, UDP, TCP, VXLAN, Packet
 from ptf.mask import Mask, MaskException
 
 
 class TestMask:
-    def test_mask__mask_simple_packet(self, scapy_simple_tcp_packet):
-        packet = scapy_simple_tcp_packet
+    def test_mask__mask_simple_packet(self, simple_tcp_packet):
+        packet = simple_tcp_packet
         mask_packet = Mask(packet)
         assert mask_packet.pkt_match(packet)
 
@@ -63,8 +61,8 @@ class TestMask:
         mask.set_care_packet(IP, "src")
         assert not mask.pkt_match(packet)
 
-    def test_mask__check_masking_conditional_field(self, scapy_simple_vxlan_packet):
-        simple_vxlan = scapy_simple_vxlan_packet
+    def test_mask__check_masking_conditional_field(self, simple_vxlan_packet):
+        simple_vxlan = simple_vxlan_packet
         simple_vxlan[VXLAN].flags = "G"
 
         masked_simple_vxlan = Mask(simple_vxlan)
@@ -94,9 +92,9 @@ class TestMask:
         ], "Only gpid field should be masked"
 
     def test_mask__conditional_field__gpid_should_be_masked_correctly(
-        self, scapy_simple_vxlan_packet
+        self, simple_vxlan_packet
     ):
-        simple_vxlan = scapy_simple_vxlan_packet  # type: Packet
+        simple_vxlan = simple_vxlan_packet  # type: Packet
         simple_vxlan[VXLAN].flags = "G"
         masked_simple_vxlan = Mask(simple_vxlan)  # type: Mask
         masked_simple_vxlan.set_do_not_care_packet(VXLAN, "gpid")
@@ -114,17 +112,17 @@ class TestMask:
         "elements_to_ignore", ((UDP, "sport"), (IP, "not_existing_field"))
     )
     def test_mask__negative__try_to_mask_not_existing_layer_or_field(
-        self, elements_to_ignore, scapy_simple_tcp_packet
+        self, elements_to_ignore, simple_tcp_packet
     ):
-        masked_packet = Mask(scapy_simple_tcp_packet)  # type: Mask
+        masked_packet = Mask(simple_tcp_packet)  # type: Mask
         with pytest.raises(MaskException):
             masked_packet.set_do_not_care_packet(
                 elements_to_ignore[0], elements_to_ignore[1]
             )
         assert not masked_packet.valid
 
-    def test_mask__validate_str_conversion(self, scapy_simple_tcp_packet):
-        masked_packet = Mask(scapy_simple_tcp_packet)  # type: Mask
+    def test_mask__validate_str_conversion(self, simple_tcp_packet):
+        masked_packet = Mask(simple_tcp_packet)  # type: Mask
         masked_packet.set_do_not_care_packet(IP, "chksum")
         assert str(masked_packet) == EXPECTED_MASKED_PACKET
 


### PR DESCRIPTION
except those few places where scapy is actually a requirement, e.g. in the code that actually imports Scapy as the selected packet manipulation module.