### PR TITLE
Use Python venv in CI tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,7 +47,9 @@ jobs:
 
     - name: Dependencies
       run: |
-        sudo apt-get install cmake libffi-dev ethtool python3-dev
+        sudo apt-get install cmake libffi-dev ethtool python3-dev python3-venv
+        python3 -m venv $HOME/ptf-test-venv
+        source $HOME/ptf-test-venv/bin/activate
         python3 -m pip install --upgrade pip setuptools nose2 wheel
         python -m pip install scapy==${{ matrix.scapy_version }}
 
@@ -57,6 +59,7 @@ jobs:
 
     - name: Install
       run: |
+        source $HOME/ptf-test-venv/bin/activate
         python3 -m pip install .
         ptf --version
 
@@ -66,6 +69,7 @@ jobs:
 
     - name: Script
       run: |
+        source $HOME/ptf-test-venv/bin/activate
         pip --verbose list
         python3 CI/check-nnpy.py
         ./CI/run_tests.sh


### PR DESCRIPTION
Without this, I have seen many failures recently on Ubuntu 22.04 that I do not know the root cause of, but using a venv gives consistently passing results.