### PR TITLE
[ptf][testutils.py::count_matched_packets] Consider only expected packets for timeout

### DIFF
--- a/src/ptf/testutils.py
+++ b/src/ptf/testutils.py
@@ -3635,14 +3635,19 @@ def count_matched_packets(test, exp_packet, port, device_number=0, timeout=None)
             "%s() requires positive timeout value." % sys._getframe().f_code.co_name
         )
 
+    last_matched_packet_time = time.time()
     total_rcv_pkt_cnt = 0
     while True:
+        if (time.time() - last_matched_packet_time) > timeout:
+            break
+
         result = dp_poll(
             test, device_number=device_number, port_number=port, timeout=timeout
         )
         if isinstance(result, test.dataplane.PollSuccess):
             if ptf.dataplane.match_exp_pkt(exp_packet, result.packet):
                 total_rcv_pkt_cnt += 1
+                last_matched_packet_time = time.time()
         else:
             break
 


### PR DESCRIPTION
`count_matched_packets` method is getting stuck in a while loop as long as ptf port receives any packet (Ex: in certain testing topologies, protocol packets (like ICMP) on ptf port are causing `count_matched_patches` method to stuck waiting for packet poll to fail). Fix is to consider only expected packets w.r.t timeout (similar to existing `count_matched_packets_all_ports` logic).

See https://github.com/sonic-net/sonic-buildimage/pull/21150 for more details on why this fix is needed.

**Testing:**
[sonic-mgmt](https://github.com/sonic-net/sonic-mgmt) tests have been running with this change for quite some time and no issues were seen.