### PR TITLE
Add copyright notices and Apache 2.0 license to files derived from oftest code

### DIFF
--- a/README-oftest.md
+++ b/README-oftest.md
@@ -1,0 +1,90 @@
+# Files in `ptf` repository derived from `oftest` repository code
+
+Some source files in the `ptf` repository were derived from code in the
+the Floodlight OFTest repository:
+
+https://github.com/floodlight/oftest
+
+The code in that repository has this copyright and license information:
+
+```
+Copyright 2010 The Board of Trustees of The Leland Stanford Junior University
+Releaesd under the OpenFlow Software License
+https://github.com/floodlight/oftest/blob/master/LICENSE
+```
+
+A copy of the OpenFlow Software License is also included in the file
+[`LICENSE.OFTest`](LICENSE.OFTest) in the `ptf` repository.
+
+Most files in this repository that were derived from `oftest` files
+have the same file name in both repositories, and are listed below
+with a mark of "S" for "same name".
+
+A few files in this repository were copied from `oftest` files and
+then renamed, and also then modified.  Those files are listed below
+with a mark of "R" for "renamed", along with the name of the `oftest`
+file from which it was derived.
+
+Most files in the `src/ptf` directory of this repository were derived
+from `oftest` code.  A few files in the `src/ptf` directory appear to
+have been developed independently of the `oftest` code.  Files marked
+with "I" below were developed independently of `oftest` code, but
+placed in the `src/ptf` directory.
+
+In particular, the `oftest` repository contains no mention of the
+`nanomsg` library.  Thus all files in the `ptf_nn` directory of this
+repository appear to be independently developed by Antonin Bas,
+without deriving it from `oftest` code.
+
+Similarly, all files in the `src/bf_pktpy` directory and its
+subdirectories were developed by engineers working for Intel
+Corporation, released under the Apache 2.0 license as part of the
+`open-p4studio` repository at https://github.com/p4lang/open-p4studio.
+Those files were copied into this repository for the convenience of
+`ptf` users that wish to use it as a non-copylefted alternative to
+Scapy.
+
+Summary of abbrevation meanings:
+
++ S - file has same name in `ptf` repository as the file from `oftest`
+  repository that it was copied from.
++ R - file was copied from `oftest` repository, then renamed, then
+  modified.
++ I - file was independently developed, not derived from any code in
+  the `oftest` repository.
+
+List of all files in directory `src/ptf` and its subdirectories, and
+whether they were derived from `oftest` code:
+
++ R `ptf` - renamed from file oft in the `oftest` repo
++ S `src/ptf/afpacket.py`
++ S `src/ptf/base_tests.py`
++ S `src/ptf/dataplane.py`
++ S `src/ptf/__init__.py`
++ I `src/ptf/mask.py` - I could find no evidence of any code in
+  `oftest` from which this could have been derived.  It appears to
+  have been independently developed by Antonin Bas.
++ I `src/ptf/netutils.py` - Originally copied from `oftest` code, then
+  later in 2025 reimplemented from scratch so that it could be
+  released under the Apache 2.0 license.
++ S `src/ptf/packet.py`
++ I `src/ptf/packet_scapy.py` - Appears to be independently developed
+  from `oftest` code, but the author explicitly chose to use the
+  OpenFlow Software License and copyright it by the same entity as
+  other `oftest` files.
++ S `src/ptf/parse.py`
++ S `src/ptf/pcap_writer.py`
++ I `src/ptf/platforms/dummy.py`
++ S `src/ptf/platforms/eth.py`
++ I `src/ptf/platforms/__init__.py`
++ S `src/ptf/platforms/local.py`
++ I `src/ptf/platforms/nn.py`
++ S `src/ptf/platforms/remote.py`
++ R `src/ptf/ptfutils.py` - renamed from file ofutils.py in the
+  `oftest` repo
++ S `src/ptf/testutils.py`
++ I `src/ptf/thriftutils.py` - Even though this file mentions `oftest`
+  in a commit comment, I can find no occurrences of terms like
+  "to_hex", "hex_to", "i16", or "i32" anywhere in the `oftest` code.
+  This appears to be original work by Antonin Bas, not derived from
+  `oftest`.

--- a/ptf
+++ b/ptf
@@ -1,4 +1,25 @@
 #!/usr/bin/env python
+# Copyright 2010 The Board of Trustees of The Leland Stanford Junior University
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# This file was derived from code in the Floodlight OFTest repository
+# https://github.com/floodlight/oftest released under the OpenFlow
+# Software License:
+# https://github.com/floodlight/oftest/blob/master/LICENSE
+# See file README-oftest.md in the ptf repository for more details.
 """
 @package ptf
 

--- a/src/ptf/__init__.py
+++ b/src/ptf/__init__.py
@@ -1,3 +1,25 @@
+# Copyright 2010 The Board of Trustees of The Leland Stanford Junior University
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# This file was derived from code in the Floodlight OFTest repository
+# https://github.com/floodlight/oftest released under the OpenFlow
+# Software License:
+# https://github.com/floodlight/oftest/blob/master/LICENSE
+# See file README-oftest.md in the ptf repository for more details.
+
 """Docstring to silence pylint; ignores --ignore option for __init__.py"""
 
 import sys

--- a/src/ptf/afpacket.py
+++ b/src/ptf/afpacket.py
@@ -1,3 +1,25 @@
+# Copyright 2010 The Board of Trustees of The Leland Stanford Junior University
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# This file was derived from code in the Floodlight OFTest repository
+# https://github.com/floodlight/oftest released under the OpenFlow
+# Software License:
+# https://github.com/floodlight/oftest/blob/master/LICENSE
+# See file README-oftest.md in the ptf repository for more details.
+
 """
 AF_PACKET receive support
 

--- a/src/ptf/base_tests.py
+++ b/src/ptf/base_tests.py
@@ -1,3 +1,25 @@
+# Copyright 2010 The Board of Trustees of The Leland Stanford Junior University
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# This file was derived from code in the Floodlight OFTest repository
+# https://github.com/floodlight/oftest released under the OpenFlow
+# Software License:
+# https://github.com/floodlight/oftest/blob/master/LICENSE
+# See file README-oftest.md in the ptf repository for more details.
+
 """
 Base classes for test cases
 

--- a/src/ptf/dataplane.py
+++ b/src/ptf/dataplane.py
@@ -1,3 +1,25 @@
+# Copyright 2010 The Board of Trustees of The Leland Stanford Junior University
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# This file was derived from code in the Floodlight OFTest repository
+# https://github.com/floodlight/oftest released under the OpenFlow
+# Software License:
+# https://github.com/floodlight/oftest/blob/master/LICENSE
+# See file README-oftest.md in the ptf repository for more details.
+
 """
 OpenFlow Test Framework
 

--- a/src/ptf/packet.py
+++ b/src/ptf/packet.py
@@ -1,3 +1,25 @@
+# Copyright 2010 The Board of Trustees of The Leland Stanford Junior University
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# This file was derived from code in the Floodlight OFTest repository
+# https://github.com/floodlight/oftest released under the OpenFlow
+# Software License:
+# https://github.com/floodlight/oftest/blob/master/LICENSE
+# See file README-oftest.md in the ptf repository for more details.
+
 """A pluggable packet module
 
 This module dynamically imports definitions from packet manipulation module,

--- a/src/ptf/packet_scapy.py
+++ b/src/ptf/packet_scapy.py
@@ -1,6 +1,27 @@
-# Distributed under the OpenFlow Software License (see LICENSE)
-# Copyright (c) 2010 The Board of Trustees of The Leland Stanford Junior University
+# Copyright 2010 The Board of Trustees of The Leland Stanford Junior University
 # Copyright (c) 2012, 2013 Big Switch Networks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# It is not clear whether this file was derived from code in the
+# Floodlight OFTest repository https://github.com/floodlight/oftest,
+# or developed independently and then released under the OpenFlow
+# Software License:
+# https://github.com/floodlight/oftest/blob/master/LICENSE
+# See file README-oftest.md in the ptf repository for more details.
+
 """
 Scapy implementation of packet manipulation module
 """

--- a/src/ptf/parse.py
+++ b/src/ptf/parse.py
@@ -1,3 +1,25 @@
+# Copyright 2010 The Board of Trustees of The Leland Stanford Junior University
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# This file was derived from code in the Floodlight OFTest repository
+# https://github.com/floodlight/oftest released under the OpenFlow
+# Software License:
+# https://github.com/floodlight/oftest/blob/master/LICENSE
+# See file README-oftest.md in the ptf repository for more details.
+
 """
 Utility parsing functions
 """

--- a/src/ptf/pcap_writer.py
+++ b/src/ptf/pcap_writer.py
@@ -1,3 +1,25 @@
+# Copyright 2010 The Board of Trustees of The Leland Stanford Junior University
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# This file was derived from code in the Floodlight OFTest repository
+# https://github.com/floodlight/oftest released under the OpenFlow
+# Software License:
+# https://github.com/floodlight/oftest/blob/master/LICENSE
+# See file README-oftest.md in the ptf repository for more details.
+
 """
 Pcap file writer
 """

--- a/src/ptf/platforms/eth.py
+++ b/src/ptf/platforms/eth.py
@@ -1,3 +1,25 @@
+# Copyright 2010 The Board of Trustees of The Leland Stanford Junior University
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# This file was derived from code in the Floodlight OFTest repository
+# https://github.com/floodlight/oftest released under the OpenFlow
+# Software License:
+# https://github.com/floodlight/oftest/blob/master/LICENSE
+# See file README-oftest.md in the ptf repository for more details.
+
 """
 Eth platform
 

--- a/src/ptf/platforms/local.py
+++ b/src/ptf/platforms/local.py
@@ -1,3 +1,25 @@
+# Copyright 2010 The Board of Trustees of The Leland Stanford Junior University
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# This file was derived from code in the Floodlight OFTest repository
+# https://github.com/floodlight/oftest released under the OpenFlow
+# Software License:
+# https://github.com/floodlight/oftest/blob/master/LICENSE
+# See file README-oftest.md in the ptf repository for more details.
+
 """
 Local platform
 

--- a/src/ptf/platforms/remote.py
+++ b/src/ptf/platforms/remote.py
@@ -1,3 +1,25 @@
+# Copyright 2010 The Board of Trustees of The Leland Stanford Junior University
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# This file was derived from code in the Floodlight OFTest repository
+# https://github.com/floodlight/oftest released under the OpenFlow
+# Software License:
+# https://github.com/floodlight/oftest/blob/master/LICENSE
+# See file README-oftest.md in the ptf repository for more details.
+
 """
 Remote platform
 

--- a/src/ptf/ptfutils.py
+++ b/src/ptf/ptfutils.py
@@ -1,3 +1,25 @@
+# Copyright 2010 The Board of Trustees of The Leland Stanford Junior University
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# This file was derived from code in the Floodlight OFTest repository
+# https://github.com/floodlight/oftest released under the OpenFlow
+# Software License:
+# https://github.com/floodlight/oftest/blob/master/LICENSE
+# See file README-oftest.md in the ptf repository for more details.
+
 """
 Utilities for the OpenFlow test framework
 """

--- a/src/ptf/testutils.py
+++ b/src/ptf/testutils.py
@@ -1,3 +1,25 @@
+# Copyright 2010 The Board of Trustees of The Leland Stanford Junior University
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# This file was derived from code in the Floodlight OFTest repository
+# https://github.com/floodlight/oftest released under the OpenFlow
+# Software License:
+# https://github.com/floodlight/oftest/blob/master/LICENSE
+# See file README-oftest.md in the ptf repository for more details.
+
 import sys
 import copy
 import logging


### PR DESCRIPTION
Only a few ptf source files appear to have been derived from oftest code.  This PR adds copyright notices and Apache-2.0 license to all of those files, along with a new README-oftest.md file explaining where these files came from, and some explanation of why other source files appear not to be derived from oftest code.

The OpenFlow Software License is not identical to a BSD-2-Clause license, but it is substantially similar to one in its terms.  Some advice I have found from Internet searches, not from talking to a lawyer, makes it sound like releasing modifications to such files under Apache 2.0 license should be legally fine.  The few files that have this status are all modified in this commit, and all have the copyright holder as "The Board of Trustees of The Leland Stanford Junior University", so they will be easy to find later if we need to update them further after double-checking this decision with Linux Foundation IP experts.