### PR TITLE
Run ptf tests through a suite to honor class and module fixtures

### DIFF
--- a/ptf
+++ b/ptf
@@ -29,6 +29,7 @@ import random
 import signal
 import fnmatch
 import copy
+import types
 from collections import OrderedDict
 
 root_dir = os.path.dirname(os.path.realpath(__file__))
@@ -656,57 +657,23 @@ def prune_tests(test_specs, test_modules):
     return result
 
 
-class PtfTestSuite(unittest.TestSuite):
-    def __init__(self, tests=(), default_test_case_timeout=None):
-        super(PtfTestSuite, self).__init__(tests)
-        self.default_test_case_timeout = default_test_case_timeout
+def apply_test_timeout(test, default_test_case_timeout=None):
+    original_run = test.run
 
-    def _run_test(self, test, result):
+    def run_with_timeout(self, result=None):
         from ptf.ptfutils import Timeout
 
-        test_case_timeout = getattr(test, "_testtimeout", None)
+        test_case_timeout = getattr(self, "_testtimeout", None)
         if test_case_timeout is None:
-            test_case_timeout = self.default_test_case_timeout
+            test_case_timeout = default_test_case_timeout
 
         if test_case_timeout:
             with Timeout(test_case_timeout):
-                test(result)
-        else:
-            test(result)
+                return original_run(result)
+        return original_run(result)
 
-    def run(self, result, debug=False):
-        top_level = False
-        if getattr(result, "_testRunEntered", False) is False:
-            result._testRunEntered = top_level = True
-
-        for index, test in enumerate(self):
-            if result.shouldStop:
-                break
-
-            if unittest.suite._isnotsuite(test):
-                self._tearDownPreviousClass(test, result)
-                self._handleModuleFixture(test, result)
-                self._handleClassSetUp(test, result)
-                result._previousTestClass = test.__class__
-
-                if getattr(test.__class__, "_classSetupFailed", False) or getattr(
-                    result, "_moduleSetUpFailed", False
-                ):
-                    continue
-
-            if not debug:
-                self._run_test(test, result)
-            else:
-                test.debug()
-
-            if self._cleanup:
-                self._removeTestAtIndex(index)
-
-        if top_level:
-            self._tearDownPreviousClass(None, result)
-            self._handleModuleTearDown(result)
-            result._testRunEntered = False
-        return result
+    test.run = types.MethodType(run_with_timeout, test)
+    return test
 
 
 def die(msg, exit_val=1):
@@ -865,9 +832,10 @@ elif config["test_order"] == "rand":
     random.seed(seed)
     random.shuffle(test_suite)
 
-test_suite = PtfTestSuite(
-    test_suite, default_test_case_timeout=config["test_case_timeout"]
-)
+test_suite = [
+    apply_test_timeout(test, config["test_case_timeout"]) for test in test_suite
+]
+test_suite = unittest.TestSuite(test_suite)
 
 
 if config["platform_dir"] is None:

--- a/ptf
+++ b/ptf
@@ -656,6 +656,59 @@ def prune_tests(test_specs, test_modules):
     return result
 
 
+class PtfTestSuite(unittest.TestSuite):
+    def __init__(self, tests=(), default_test_case_timeout=None):
+        super(PtfTestSuite, self).__init__(tests)
+        self.default_test_case_timeout = default_test_case_timeout
+
+    def _run_test(self, test, result):
+        from ptf.ptfutils import Timeout
+
+        test_case_timeout = getattr(test, "_testtimeout", None)
+        if test_case_timeout is None:
+            test_case_timeout = self.default_test_case_timeout
+
+        if test_case_timeout:
+            with Timeout(test_case_timeout):
+                test(result)
+        else:
+            test(result)
+
+    def run(self, result, debug=False):
+        top_level = False
+        if getattr(result, "_testRunEntered", False) is False:
+            result._testRunEntered = top_level = True
+
+        for index, test in enumerate(self):
+            if result.shouldStop:
+                break
+
+            if unittest.suite._isnotsuite(test):
+                self._tearDownPreviousClass(test, result)
+                self._handleModuleFixture(test, result)
+                self._handleClassSetUp(test, result)
+                result._previousTestClass = test.__class__
+
+                if getattr(test.__class__, "_classSetupFailed", False) or getattr(
+                    result, "_moduleSetUpFailed", False
+                ):
+                    continue
+
+            if not debug:
+                self._run_test(test, result)
+            else:
+                test.debug()
+
+            if self._cleanup:
+                self._removeTestAtIndex(index)
+
+        if top_level:
+            self._tearDownPreviousClass(None, result)
+            self._handleModuleTearDown(result)
+            result._testRunEntered = False
+        return result
+
+
 def die(msg, exit_val=1):
     logging.critical(msg)
     sys.exit(exit_val)
@@ -812,6 +865,10 @@ elif config["test_order"] == "rand":
     random.seed(seed)
     random.shuffle(test_suite)
 
+test_suite = PtfTestSuite(
+    test_suite, default_test_case_timeout=config["test_case_timeout"]
+)
+
 
 if config["platform_dir"] is None:
     from ptf import platforms
@@ -894,38 +951,16 @@ if __name__ == "__main__":
         )
     else:
         runner = unittest.TextTestRunner(verbosity=2)
-    test_case_timeout = config["test_case_timeout"]
-    run_failures = []
-    run_errors = []
+    result = runner.run(test_suite)
+    run_failures = result.failures
+    run_errors = result.errors
     run_timeouts = []
-    from ptf.ptfutils import Timeout
-
-    for t in test_suite:
-        if t._testtimeout is not None:
-            this_test_timeout = t._testtimeout
-        else:
-            this_test_timeout = test_case_timeout
-
-        if this_test_timeout:
-            with Timeout(this_test_timeout):
-                result = runner.run(t)
-        else:
-            result = runner.run(t)
-
-        run_failures.extend(result.failures)
-        run_errors.extend(result.errors)
-
-        if this_test_timeout:
-            for case in result.errors:
-                traceback_str = case[1]
-                # TODO: hacky? could not think of a better way
-                if "raise Timeout.TimeoutError()" in traceback_str:
-                    logging.info("Test case failed because of timeout")
-                    run_timeouts.append(case)
-
-        if config["failfast"] and not result.wasSuccessful():
-            logging.info("Test failed and failfast mode enabled, stopping")
-            break
+    for case in result.errors:
+        traceback_str = case[1]
+        # TODO: hacky? could not think of a better way
+        if "raise Timeout.TimeoutError()" in traceback_str:
+            logging.info("Test case failed because of timeout")
+            run_timeouts.append(case)
 
     ptf.open_logfile("main")
     if ptf.testutils.skipped_test_count > 0:

--- a/utests/specs/fixtures.py
+++ b/utests/specs/fixtures.py
@@ -1,0 +1,57 @@
+# Copyright 2026
+# SPDX-License-Identifier: Apache-2.0
+
+from ptf.base_tests import BaseTest
+
+
+module_events = []
+
+
+def setUpModule():
+    module_events.append("setUpModule")
+    print(">>>setUpModule")
+
+
+def tearDownModule():
+    module_events.append("tearDownModule")
+    print(">>>tearDownModule")
+
+
+class ModuleFixtureProbeOne(BaseTest):
+    class_events = []
+
+    @classmethod
+    def setUpClass(cls):
+        cls.class_events.append("setUpClass")
+        print(">>>ModuleFixtureProbeOne.setUpClass")
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.class_events.append("tearDownClass")
+        print(">>>ModuleFixtureProbeOne.tearDownClass")
+
+    def setUp(self):
+        BaseTest.setUp(self)
+
+    def runTest(self):
+        print(">>>ModuleFixtureProbeOne.runTest")
+
+
+class ModuleFixtureProbeTwo(BaseTest):
+    class_events = []
+
+    @classmethod
+    def setUpClass(cls):
+        cls.class_events.append("setUpClass")
+        print(">>>ModuleFixtureProbeTwo.setUpClass")
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.class_events.append("tearDownClass")
+        print(">>>ModuleFixtureProbeTwo.tearDownClass")
+
+    def setUp(self):
+        BaseTest.setUp(self)
+
+    def runTest(self):
+        print(">>>ModuleFixtureProbeTwo.runTest")

--- a/utests/tests/test.py
+++ b/utests/tests/test.py
@@ -87,3 +87,30 @@ class TestParamsTestCase(BaseTestCase):
         testspec = "test.TestParamGet"
         out = self.do_test_params(testspec, test_params_str)
         self.assertIn("Error when parsing test params", out)
+
+
+class FixturesTestCase(BaseTestCase):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.testdir = "utests/specs"
+
+    def test_module_and_class_fixtures_run(self):
+        rc, out = self.run_ptf(
+            args=[
+                "--test-dir",
+                self.testdir,
+                "--platform",
+                "dummy",
+                "fixtures.ModuleFixtureProbeOne",
+                "fixtures.ModuleFixtureProbeTwo",
+            ]
+        )
+        self.assertEqual(rc, 0)
+        self.assertEqual(out.count(">>>setUpModule"), 1)
+        self.assertEqual(out.count(">>>tearDownModule"), 1)
+        self.assertEqual(out.count(">>>ModuleFixtureProbeOne.setUpClass"), 1)
+        self.assertEqual(out.count(">>>ModuleFixtureProbeOne.tearDownClass"), 1)
+        self.assertEqual(out.count(">>>ModuleFixtureProbeTwo.setUpClass"), 1)
+        self.assertEqual(out.count(">>>ModuleFixtureProbeTwo.tearDownClass"), 1)
+        self.assertIn(">>>ModuleFixtureProbeOne.runTest", out)
+        self.assertIn(">>>ModuleFixtureProbeTwo.runTest", out)


### PR DESCRIPTION
ptf previously invoked the unittest runner once per individual test case. That bypassed unittest's normal suite-level handling, so setUpModule/tearDownModule and setUpClass/tearDownClass were not executed as expected.

Switch the launcher to build a unittest.TestSuite subclass and run the selected tests as a suite. Keep the existing per-test timeout behavior by applying timeouts inside the suite's per-test execution path, so test selection, ordering, sharding, failfast, and timeout handling remain compatible with the previous wrapper behavior.

Add a focused fixture probe module that exercises module- and class-scoped fixtures so this behavior is covered explicitly.