### PR TITLE
Use proper upstream workflow file

### DIFF
--- a/.github/workflows/monthly-release.yml
+++ b/.github/workflows/monthly-release.yml
@@ -16,7 +16,7 @@ permissions:
 jobs:
   monthly-release:
     if: ${{ github.repository == 'p4lang/ptf' }}
-    uses: p4lang/.github/.github/workflows/bump-version.yml@main
+    uses: p4lang/.github/.github/workflows/monthly-release.yml@main
     with:
       version_file: Version.txt
       reviewers: fruffy, jafingerhut


### PR DESCRIPTION
Part II of fumbling the workflow names.

I must have used the temporary "new" upstream files when I created this repo's monthly release, and didn't change it when I switched the old names back.